### PR TITLE
Add config admin SPA — PKCE OAuth, no server-side session

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -137,10 +137,18 @@ func runConfigServer() error {
 	svc := service.NewConfigService(repo, backupMgr)
 
 	router := confighandler.NewRouter(confighandler.Deps{
-		Service:  svc,
-		Verifier: verifier,
-		Version:  version,
+		Service:           svc,
+		Verifier:          verifier,
+		Version:           version,
+		IdentityPublicURL: cfg.IdentityPublicURL,
+		OAuthClientID:     cfg.OAuthClientID,
 	})
+	if cfg.OAuthClientID != "" && cfg.IdentityPublicURL != "" {
+		log.Printf("config: admin UI mounted at /; oauth client_id=%s, identity public url=%s",
+			cfg.OAuthClientID, cfg.IdentityPublicURL)
+	} else {
+		log.Println("config: admin UI disabled (set OAUTH_CLIENT_ID and IDENTITY_PUBLIC_URL to enable)")
+	}
 
 	// Context + background tasks
 	ctx, cancel := context.WithCancel(context.Background())
@@ -168,7 +176,7 @@ func runConfigServer() error {
 		log.Println("rate limiting disabled (RATE_LIMIT_DISABLED)")
 	}
 
-	handler = configSecurityHeaders(handler, cfg.CORSOrigins, cfg.Env == config.EnvDevelopment)
+	handler = configSecurityHeaders(handler, cfg.CORSOrigins, cfg.IdentityPublicURL, cfg.Env == config.EnvDevelopment)
 
 	// OpenAPI + discovery endpoints are served directly on the raw mux
 	// inside the router; nothing to register here yet. (Added in M4.)
@@ -260,20 +268,54 @@ func originAllowed(origin string, allowed map[string]bool, devMode bool) bool {
 	return devMode && len(allowed) == 0
 }
 
-// configSecurityHeaders wraps the router with a slimmer CSP than identity's.
-// Config serves only JSON APIs and /healthz — no HTML, no forms, no OAuth
-// redirects — so the CSP can be strict.
-func configSecurityHeaders(next http.Handler, corsOrigins []string, devMode bool) http.Handler {
+// configSecurityHeaders wraps the router with two CSPs and CORS for the
+// JSON API. Config has two surfaces:
+//
+//   - The /, /static/*, and /spa-config.json paths serve the admin SPA.
+//     They need a permissive-enough CSP to load same-origin scripts and
+//     stylesheets, and to reach identity's /oauth/* endpoints from JS.
+//   - The /api/*, /healthz, /openapi.* paths return JSON only and get
+//     the strictest CSP we can.
+//
+// Both responses set the static security headers (no-sniff, frame-deny,
+// HSTS, referrer-policy=no-referrer) regardless.
+func configSecurityHeaders(next http.Handler, corsOrigins []string, identityURL string, devMode bool) http.Handler {
 	allowed := make(map[string]bool, len(corsOrigins))
 	for _, o := range corsOrigins {
 		allowed[o] = true
 	}
+
+	// Pre-build the SPA CSP. connect-src and form-action need to allow
+	// the identity service so the OAuth flow can redirect there and the
+	// SPA can fetch /oauth/token. img-src allows data: for the inline
+	// favicon.
+	spaCSP := "default-src 'self'; " +
+		"script-src 'self'; " +
+		"style-src 'self'; " +
+		"img-src 'self' data:; " +
+		"connect-src 'self'"
+	if identityURL != "" {
+		spaCSP += " " + identityURL
+	}
+	spaCSP += "; form-action 'self'"
+	if identityURL != "" {
+		spaCSP += " " + identityURL
+	}
+	spaCSP += "; base-uri 'self'; frame-ancestors 'none'"
+
+	const apiCSP = "default-src 'none'; frame-ancestors 'none'"
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "no-referrer")
 		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
-		w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'")
+
+		if isSPAPath(r.URL.Path) {
+			w.Header().Set("Content-Security-Policy", spaCSP)
+		} else {
+			w.Header().Set("Content-Security-Policy", apiCSP)
+		}
 
 		if strings.HasPrefix(r.URL.Path, "/api/") {
 			w.Header().Set("Vary", "Origin")
@@ -291,5 +333,11 @@ func configSecurityHeaders(next http.Handler, corsOrigins []string, devMode bool
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isSPAPath reports whether the request path serves the admin UI. Used
+// by configSecurityHeaders to choose between the SPA and API CSPs.
+func isSPAPath(p string) bool {
+	return p == "/" || p == "/spa-config.json" || strings.HasPrefix(p, "/static/")
 }
 

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -150,6 +150,14 @@ func runConfigServer() error {
 		log.Println("config: admin UI disabled (set OAUTH_CLIENT_ID and IDENTITY_PUBLIC_URL to enable)")
 	}
 
+	// Loud warning when dev-mode is active and no explicit CORS allow
+	// list is set: originAllowed will let *any* http://localhost:* origin
+	// drive the API. That's intentional for local dev but dangerous if
+	// IDENTITY_ENV is accidentally left unset on a public host.
+	if cfg.Env == config.EnvDevelopment && len(cfg.CORSOrigins) == 0 {
+		log.Println("WARNING: development mode + empty CORS_ORIGINS → ANY http://localhost:* origin is allowed; set IDENTITY_ENV=production or list explicit origins for non-dev hosts")
+	}
+
 	// Context + background tasks
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/server/identity.go
+++ b/cmd/server/identity.go
@@ -483,6 +483,8 @@ func jwksHandler(issuer *auth.TokenIssuer) http.Handler {
 // If "http://localhost" (no port) appears in the allowlist, it matches any
 // http://localhost:PORT origin, enabling a single CORS_ORIGINS entry to cover
 // all local dev ports.
+// Wildcard entries like "https://*.example.com" match any
+// "https://<subdomain>.example.com" origin with the same scheme.
 func isAllowedOrigin(origin string, allowed map[string]bool, devMode bool) bool {
 	if allowed[origin] {
 		return true
@@ -491,7 +493,24 @@ func isAllowedOrigin(origin string, allowed map[string]bool, devMode bool) bool 
 	// "http://localhost.attacker.example" would match. Parse the origin
 	// and compare host explicitly.
 	u, err := url.Parse(origin)
-	if err != nil || u.Scheme != "http" {
+	if err != nil {
+		return false
+	}
+
+	// Wildcard subdomain matching: "https://*.example.com" in the allowlist
+	// matches any "https://<subdomain>.example.com". Scheme must match.
+	// u.Hostname() strips any port before the suffix check.
+	for entry := range allowed {
+		wu, err := url.Parse(entry)
+		if err != nil || wu.Scheme != u.Scheme || !strings.HasPrefix(wu.Host, "*.") {
+			continue
+		}
+		if strings.HasSuffix(u.Hostname(), wu.Host[1:]) {
+			return true
+		}
+	}
+
+	if u.Scheme != "http" {
 		return false
 	}
 	isLocalhostHost := u.Host == "localhost" || strings.HasPrefix(u.Host, "localhost:")

--- a/cmd/server/security_headers_test.go
+++ b/cmd/server/security_headers_test.go
@@ -67,6 +67,38 @@ func TestIsAllowedOrigin_LocalhostWildcard_DoesNotMatchLocalhostSubdomain(t *tes
 	assert.False(t, isAllowedOrigin("http://localhost.evil.com", allowed, false))
 }
 
+func TestIsAllowedOrigin_SubdomainWildcard_MatchesSubdomain(t *testing.T) {
+	allowed := map[string]bool{"https://*.example.com": true}
+	assert.True(t, isAllowedOrigin("https://app.example.com", allowed, false))
+	assert.True(t, isAllowedOrigin("https://config.example.com", allowed, false))
+}
+
+func TestIsAllowedOrigin_SubdomainWildcard_DoesNotMatchParentDomain(t *testing.T) {
+	allowed := map[string]bool{"https://*.example.com": true}
+	assert.False(t, isAllowedOrigin("https://example.com", allowed, false))
+}
+
+func TestIsAllowedOrigin_SubdomainWildcard_DoesNotMatchWrongScheme(t *testing.T) {
+	allowed := map[string]bool{"https://*.example.com": true}
+	assert.False(t, isAllowedOrigin("http://app.example.com", allowed, false))
+}
+
+func TestIsAllowedOrigin_SubdomainWildcard_DoesNotMatchUnrelatedDomain(t *testing.T) {
+	allowed := map[string]bool{"https://*.example.com": true}
+	assert.False(t, isAllowedOrigin("https://evil.com", allowed, false))
+}
+
+func TestIsAllowedOrigin_SubdomainWildcard_DoesNotMatchSuffixWithoutDot(t *testing.T) {
+	// "evilexample.com" must not match "*.example.com"
+	allowed := map[string]bool{"https://*.example.com": true}
+	assert.False(t, isAllowedOrigin("https://evilexample.com", allowed, false))
+}
+
+func TestIsAllowedOrigin_SubdomainWildcard_MatchesWithPort(t *testing.T) {
+	allowed := map[string]bool{"https://*.example.com": true}
+	assert.True(t, isAllowedOrigin("https://app.example.com:8443", allowed, false))
+}
+
 // ---------------------------------------------------------------------------
 // securityHeaders — CORS behaviour
 // ---------------------------------------------------------------------------

--- a/deploy/config-env.example
+++ b/deploy/config-env.example
@@ -47,3 +47,15 @@ IDENTITY_ISSUER=https://id.example.com
 # R2_ACCESS_KEY_ID=
 # R2_SECRET_ACCESS_KEY=
 # R2_BUCKET_NAME=
+
+# Admin UI (optional). When OAUTH_CLIENT_ID is set, an admin SPA is
+# mounted at / for browser-based namespace CRUD. The SPA authenticates
+# via OAuth Authorization Code + PKCE against identity. Register the
+# client first in identity's /admin/oauth UI with redirect URI
+# matching this service's public URL (e.g. https://config.example.com/).
+# OAUTH_CLIENT_ID=config-spa
+
+# IDENTITY_PUBLIC_URL — the URL the browser uses to reach identity.
+# Defaults to IDENTITY_ISSUER_URL; only needed when identity sits behind
+# a reverse proxy with a different public hostname.
+# IDENTITY_PUBLIC_URL=https://id.example.com

--- a/deploy/config.service
+++ b/deploy/config.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Homelab config service
+Description=swee.net config service
 After=network.target identity.service
 Wants=identity.service
 Documentation=https://github.com/sweeney/identity

--- a/docs/config-admin.md
+++ b/docs/config-admin.md
@@ -246,6 +246,111 @@ Both sides must be in lockstep: leaving config flagged on while
 identity doesn't emit `aud` will reject every request. The feature is
 off by default to keep the v1 JWT shape compatible.
 
+## Admin UI (optional)
+
+The config service can serve a small browser SPA at `/` for managing
+namespaces (list, view, edit JSON document, change ACL, delete). The
+SPA is **off by default** — set `OAUTH_CLIENT_ID` and
+`IDENTITY_PUBLIC_URL` in the env file to enable it.
+
+Architecture:
+
+- The SPA is a single `index.html` + a few static `.js` / `.css` files,
+  embedded into the binary at `internal/ui-config/static/`.
+- It authenticates against identity via OAuth Authorization Code with
+  PKCE (the same flow `examples/spa-demo` uses). Tokens land in
+  `localStorage`; the SPA calls `/api/v1/config/*` with a `Bearer`
+  header.
+- There is no server-side session, no cookie crypto, no CSRF
+  middleware — all auth state is in the browser.
+- A path-aware CSP keeps `/api/*` locked to `default-src 'none'`
+  while permitting `script-src 'self'` + the identity origin in
+  `connect-src`/`form-action` for the SPA.
+
+### 1. Register the OAuth client on identity
+
+In identity's admin UI (`https://id.example.com/admin/oauth`), click
+**New OAuth client** and fill in:
+
+| Field | Value |
+|---|---|
+| Client ID | `config-spa` (or any unique slug) |
+| Name | `Config Admin SPA` |
+| Redirect URIs | `https://config.example.com/` (one per line) |
+| Grant types | `authorization_code`, `refresh_token` |
+| Token endpoint auth method | `none` (public client; PKCE is the secret) |
+| Scopes | leave blank |
+| Audience | leave blank |
+
+Save. Note the client ID — you'll feed it to config below.
+
+PKCE is **mandatory** for `none` auth — identity's authorize endpoint
+already enforces this.
+
+### 2. Configure config service
+
+Add to `/etc/identity/config.env`:
+
+```
+OAUTH_CLIENT_ID=config-spa
+IDENTITY_PUBLIC_URL=https://id.example.com
+```
+
+`IDENTITY_PUBLIC_URL` defaults to `IDENTITY_ISSUER_URL`, so this line
+is optional when both are the same hostname (typical for homelab).
+Restart `config.service`. The startup log will print:
+
+```
+config: admin UI mounted at /; oauth client_id=config-spa, identity public url=https://id.example.com
+```
+
+### 3. Cloudflared route
+
+If you tunnel both services from one Cloudflare Tunnel, your
+`config.yml` looks like:
+
+```yaml
+tunnel: <tunnel-uuid>
+credentials-file: /etc/cloudflared/<uuid>.json
+
+ingress:
+  - hostname: id.example.com
+    service: http://localhost:8181
+  - hostname: config.example.com
+    service: http://localhost:8282
+  - service: http_status:404
+```
+
+Then DNS-route `config.example.com` to the tunnel:
+
+```
+cloudflared tunnel route dns <tunnel-uuid> config.example.com
+```
+
+Visit `https://config.example.com/` in a browser. You'll be redirected
+to identity for login (existing passkey/password works). After signing
+in, identity redirects back with `?code=…`; the SPA exchanges it for
+tokens and lands on the namespace list.
+
+### 4. Threat-model notes
+
+- **localStorage tokens are XSS-readable.** This is acceptable here
+  because (a) the SPA loads no third-party scripts, (b) CSP forbids
+  inline scripts and `eval`, and (c) the threat model is a
+  single-admin homelab, not a SaaS with many tenants. If your
+  deployment differs (third-party scripts, multiple users), consider
+  a backend-for-frontend (BFF) pattern instead.
+- **CSP is restrictive but pragmatic.** `script-src 'self'` only;
+  `connect-src` includes identity for OAuth; `frame-ancestors 'none'`
+  prevents click-jacking.
+- **Tab lifetime.** Access tokens expire in 15 min; the SPA
+  auto-refreshes via the refresh token. PKCE state lives in
+  `sessionStorage` so a half-finished login doesn't leak across
+  browser sessions.
+- **No revocation push.** As with the API, disabling a user on
+  identity does not immediately log them out of config — see
+  "Revocation lag" above.
+
 ## Configuration reference
 
 Environment variables for the config service (systemd env file typically
@@ -264,3 +369,6 @@ at `/etc/identity/config.env`):
 | `CORS_ORIGINS` | (unset) | Comma-separated allowed origins |
 | `RATE_LIMIT_DISABLED` | `0` | `1` disables rate limiting (dev/test only) |
 | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME` | (unset) | Required together for backups |
+| `OAUTH_CLIENT_ID` | (unset) | Public OAuth client_id registered on identity. Mounts the admin SPA at `/` when set. |
+| `IDENTITY_PUBLIC_URL` | `IDENTITY_ISSUER_URL` | URL the *browser* uses to reach identity (overrides the issuer URL when behind a reverse proxy with a different public hostname). |
+| `REQUIRED_AUDIENCE` | (unset) | Asserts incoming JWTs carry a matching `aud`. Mitigation against cross-service token replay; off until identity stamps `aud` on issuance. |

--- a/internal/config/configsvc.go
+++ b/internal/config/configsvc.go
@@ -45,6 +45,18 @@ type ConfigSvcConfig struct {
 	// empty until identity stamps a matching audience on issuance.
 	RequiredAudience string
 
+	// IdentityPublicURL is the URL the *browser* should hit for OAuth
+	// authorize / token endpoints — usually the same as
+	// IdentityIssuerURL but may differ if identity sits behind a reverse
+	// proxy with a public hostname distinct from the in-cluster URL.
+	// Empty disables the admin UI; only the API is served.
+	IdentityPublicURL string
+
+	// OAuthClientID is the public OAuth client_id registered on identity
+	// for the config admin SPA. Public client (no secret) using PKCE.
+	// Empty disables the admin UI.
+	OAuthClientID string
+
 	TrustProxy        string
 	CORSOrigins       []string
 	RateLimitDisabled bool
@@ -122,6 +134,17 @@ func LoadConfigSvc() (*ConfigSvcConfig, error) {
 	}
 
 	cfg.RequiredAudience = os.Getenv("REQUIRED_AUDIENCE")
+
+	cfg.IdentityPublicURL = os.Getenv("IDENTITY_PUBLIC_URL")
+	if cfg.IdentityPublicURL == "" {
+		cfg.IdentityPublicURL = cfg.IdentityIssuerURL
+	}
+	if cfg.IdentityPublicURL != "" {
+		if err := validateIdentityIssuerURL(cfg.IdentityPublicURL); err != nil {
+			errs = append(errs, fmt.Errorf("IDENTITY_PUBLIC_URL: %w", err))
+		}
+	}
+	cfg.OAuthClientID = os.Getenv("OAUTH_CLIENT_ID")
 
 	if v := os.Getenv("JWKS_CACHE_TTL"); v != "" {
 		d, err := time.ParseDuration(v)

--- a/internal/config/configsvc_test.go
+++ b/internal/config/configsvc_test.go
@@ -20,7 +20,8 @@ func clearConfigSvcEnv(t *testing.T) {
 	for _, k := range []string{
 		"IDENTITY_ENV", "PORT", "DB_PATH",
 		"IDENTITY_ISSUER_URL", "IDENTITY_ISSUER",
-		"JWKS_CACHE_TTL", "BACKUP_MIN_INTERVAL",
+		"IDENTITY_PUBLIC_URL", "OAUTH_CLIENT_ID",
+		"JWKS_CACHE_TTL", "BACKUP_MIN_INTERVAL", "REQUIRED_AUDIENCE",
 		"TRUST_PROXY", "CORS_ORIGINS", "RATE_LIMIT_DISABLED",
 		"R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_BUCKET_NAME",
 	} {
@@ -207,6 +208,35 @@ func TestLoadConfigSvc_R2PartiallyConfigured_NotConfigured(t *testing.T) {
 				"R2Configured must require ALL four vars, missing %s", omitted)
 		})
 	}
+}
+
+func TestLoadConfigSvc_IdentityPublicURLFallsBackToIssuerURL(t *testing.T) {
+	clearConfigSvcEnv(t)
+	t.Setenv("IDENTITY_ISSUER_URL", "http://id.local:9000")
+
+	cfg, err := config.LoadConfigSvc()
+	require.NoError(t, err)
+	assert.Equal(t, "http://id.local:9000", cfg.IdentityPublicURL,
+		"IDENTITY_PUBLIC_URL defaults to IDENTITY_ISSUER_URL so most homelab deployments don't need both")
+}
+
+func TestLoadConfigSvc_OAuthClientID(t *testing.T) {
+	clearConfigSvcEnv(t)
+	t.Setenv("OAUTH_CLIENT_ID", "config-spa")
+
+	cfg, err := config.LoadConfigSvc()
+	require.NoError(t, err)
+	assert.Equal(t, "config-spa", cfg.OAuthClientID)
+}
+
+func TestLoadConfigSvc_IdentityPublicURL_ShapeValidated(t *testing.T) {
+	clearConfigSvcEnv(t)
+	t.Setenv("IDENTITY_ISSUER_URL", "http://id.local")
+	t.Setenv("IDENTITY_PUBLIC_URL", "http://id.local?bad=1")
+
+	_, err := config.LoadConfigSvc()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "IDENTITY_PUBLIC_URL")
 }
 
 func TestLoadConfigSvc_IdentityIssuerFallsBackToURL(t *testing.T) {

--- a/internal/handler/config/router.go
+++ b/internal/handler/config/router.go
@@ -13,11 +13,14 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"html/template"
 	"io"
 	"io/fs"
 	"net/http"
+	"strings"
 
 	"github.com/sweeney/identity/internal/auth"
 	"github.com/sweeney/identity/internal/domain"
@@ -112,14 +115,35 @@ func NewRouter(d Deps) *Router {
 // mountSPA wires the admin UI at /, the static asset tree at /static/*,
 // and the bootstrap config at /spa-config.json. All three are unauth —
 // authentication is performed entirely client-side via PKCE.
+//
+// index.html is rendered as a Go template once at construction so
+// /static/*.js URLs carry ?v={{AssetVer}} cache-busters. Without that,
+// browsers cache the JS bundle indefinitely and a deploy goes
+// unnoticed until the user clears their cache. Static assets
+// themselves are served from the embedded FS with directory listings
+// disabled — http.FileServer's default of rendering an HTML index
+// for a directory request would otherwise enumerate every embedded
+// file at GET /static/.
 func mountSPA(mux *http.ServeMux, identityURL, clientID string) {
 	indexBytes, err := uiconfig.StaticFS.ReadFile("static/index.html")
 	if err != nil {
-		// Embed failures are programmer errors and have already failed
-		// at compile time; treat a runtime error here as fatal-ish by
-		// rendering a stub so the rest of the API still works.
 		indexBytes = []byte("config admin UI assets missing")
 	}
+	indexTmpl, tmplErr := template.New("index").Parse(string(indexBytes))
+
+	// Pre-render once: AssetVer is fixed for the process lifetime so
+	// there's no need to execute the template on every request.
+	var indexRendered []byte
+	if tmplErr == nil {
+		var buf bytes.Buffer
+		if err := indexTmpl.Execute(&buf, struct{ AssetVer string }{uiconfig.AssetVersion}); err == nil {
+			indexRendered = buf.Bytes()
+		}
+	}
+	if indexRendered == nil {
+		indexRendered = indexBytes // fall back to literal bytes; cache-busting will be a no-op
+	}
+
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		// Reject anything other than the root path so unknown routes
 		// don't accidentally render the SPA shell with a 200.
@@ -129,11 +153,11 @@ func mountSPA(mux *http.ServeMux, identityURL, clientID string) {
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-		_, _ = w.Write(indexBytes)
+		_, _ = w.Write(indexRendered)
 	})
 
 	staticSub, _ := fs.Sub(uiconfig.StaticFS, "static")
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
+	mux.Handle("GET /static/", http.StripPrefix("/static/", noListing(http.FileServer(http.FS(staticSub)))))
 
 	mux.HandleFunc("GET /spa-config.json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -142,6 +166,20 @@ func mountSPA(mux *http.ServeMux, identityURL, clientID string) {
 			"identity_url": identityURL,
 			"client_id":    clientID,
 		})
+	})
+}
+
+// noListing wraps an http.FileServer so directory paths return 404
+// instead of an auto-generated HTML index. The check is path-shape
+// only — Go's mux + StripPrefix already canonicalise away ".." escapes
+// before the request reaches us.
+func noListing(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "" || strings.HasSuffix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		h.ServeHTTP(w, r)
 	})
 }
 

--- a/internal/handler/config/router.go
+++ b/internal/handler/config/router.go
@@ -16,12 +16,14 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/fs"
 	"net/http"
 
 	"github.com/sweeney/identity/internal/auth"
 	"github.com/sweeney/identity/internal/domain"
 	"github.com/sweeney/identity/internal/service"
 	"github.com/sweeney/identity/internal/spec"
+	uiconfig "github.com/sweeney/identity/internal/ui-config"
 )
 
 // maxBodyBytes caps the request body size the handlers will read. The
@@ -46,6 +48,13 @@ type Deps struct {
 	Service  *service.ConfigService
 	Verifier auth.TokenParser
 	Version  string // populated into /healthz for parity with identity
+
+	// SPA bootstrap. When IdentityPublicURL is non-empty the admin UI
+	// is mounted at "/" and the bootstrap config is served at
+	// /spa-config.json. Leave both empty to disable the UI entirely
+	// (the API stays up regardless).
+	IdentityPublicURL string
+	OAuthClientID     string
 }
 
 // NewRouter builds the config service router. The service layer holds the
@@ -92,7 +101,48 @@ func NewRouter(d Deps) *Router {
 	mux.Handle("POST /api/v1/config/namespaces", authed(createHandler(d.Service)))
 	mux.Handle("PATCH /api/v1/config/namespaces/{ns}", authed(updateACLHandler(d.Service)))
 
+	// SPA bundle (optional — only mounted when an OAuth client is configured).
+	if d.IdentityPublicURL != "" && d.OAuthClientID != "" {
+		mountSPA(mux, d.IdentityPublicURL, d.OAuthClientID)
+	}
+
 	return &Router{mux: mux}
+}
+
+// mountSPA wires the admin UI at /, the static asset tree at /static/*,
+// and the bootstrap config at /spa-config.json. All three are unauth —
+// authentication is performed entirely client-side via PKCE.
+func mountSPA(mux *http.ServeMux, identityURL, clientID string) {
+	indexBytes, err := uiconfig.StaticFS.ReadFile("static/index.html")
+	if err != nil {
+		// Embed failures are programmer errors and have already failed
+		// at compile time; treat a runtime error here as fatal-ish by
+		// rendering a stub so the rest of the API still works.
+		indexBytes = []byte("config admin UI assets missing")
+	}
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		// Reject anything other than the root path so unknown routes
+		// don't accidentally render the SPA shell with a 200.
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		_, _ = w.Write(indexBytes)
+	})
+
+	staticSub, _ := fs.Sub(uiconfig.StaticFS, "static")
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticSub))))
+
+	mux.HandleFunc("GET /spa-config.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-cache")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"identity_url": identityURL,
+			"client_id":    clientID,
+		})
+	})
 }
 
 // requireUserToken rejects requests that authed with a service token AND

--- a/internal/handler/config/router_test.go
+++ b/internal/handler/config/router_test.go
@@ -435,6 +435,86 @@ func TestCreate_MalformedJSON_Returns400(t *testing.T) {
 	assert.Contains(t, string(body), "invalid_request")
 }
 
+// --- SPA bundle ---
+
+// newHarnessWithSPA spins up a router with the admin-UI bundle mounted,
+// using the test issuer's URL as the SPA's identity_url.
+func newHarnessWithSPA(t *testing.T) *harness {
+	t.Helper()
+	key, err := auth.GenerateKey()
+	require.NoError(t, err)
+	issuer, err := auth.NewTokenIssuer(key, nil, "https://test", 5*time.Minute)
+	require.NoError(t, err)
+
+	repo := newFakeRepo()
+	svc := service.NewConfigService(repo, fakeBackup{})
+	router := confighandler.NewRouter(confighandler.Deps{
+		Service:           svc,
+		Verifier:          issuer,
+		Version:           "test",
+		IdentityPublicURL: "https://id.example.com",
+		OAuthClientID:     "config-spa",
+	})
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	mint := func(role domain.Role, sub string) string {
+		tok, err := issuer.Mint(domain.TokenClaims{UserID: sub, Username: sub, Role: role, IsActive: true})
+		require.NoError(t, err)
+		return tok
+	}
+	return &harness{
+		t: t, issuer: issuer, repo: repo, srv: srv,
+		adminTok: mint(domain.RoleAdmin, "admin-1"),
+		userTok:  mint(domain.RoleUser, "user-1"),
+	}
+}
+
+func TestSPA_IndexServedAtRoot(t *testing.T) {
+	h := newHarnessWithSPA(t)
+	resp, body := h.do("GET", "/", "", nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+	assert.Contains(t, string(body), "<title>Config Admin</title>")
+	assert.Contains(t, string(body), "/static/app.js")
+}
+
+func TestSPA_StaticAssetsServed(t *testing.T) {
+	h := newHarnessWithSPA(t)
+	for _, path := range []string{"/static/app.js", "/static/style.css", "/static/auth.js", "/static/api.js", "/static/editor.js"} {
+		t.Run(path, func(t *testing.T) {
+			resp, body := h.do("GET", path, "", nil)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "expected %s to be served", path)
+			assert.NotEmpty(t, body)
+		})
+	}
+}
+
+func TestSPA_BootstrapConfigJSON(t *testing.T) {
+	h := newHarnessWithSPA(t)
+	resp, body := h.do("GET", "/spa-config.json", "", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "json")
+	var cfg map[string]string
+	require.NoError(t, json.Unmarshal(body, &cfg))
+	assert.Equal(t, "https://id.example.com", cfg["identity_url"],
+		"SPA must learn the identity URL via /spa-config.json so the OAuth flow can target it")
+	assert.Equal(t, "config-spa", cfg["client_id"])
+}
+
+func TestSPA_NotMountedWhenDepsEmpty(t *testing.T) {
+	// When IdentityPublicURL or OAuthClientID is unset, the SPA bundle
+	// is intentionally not mounted — config stays a pure API server.
+	h := newHarness(t) // existing factory: no SPA deps
+	for _, path := range []string{"/", "/static/app.js", "/spa-config.json"} {
+		t.Run(path, func(t *testing.T) {
+			resp, _ := h.do("GET", path, "", nil)
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+				"%s must 404 when SPA is disabled", path)
+		})
+	}
+}
+
 // --- OpenAPI ---
 
 func TestOpenAPI_YAML_Unauth(t *testing.T) {

--- a/internal/handler/config/router_test.go
+++ b/internal/handler/config/router_test.go
@@ -515,6 +515,37 @@ func TestSPA_NotMountedWhenDepsEmpty(t *testing.T) {
 	}
 }
 
+// TestSPA_DirectoryListingRefused asserts that http.FileServer's default
+// "render an HTML index for a directory request" behaviour is suppressed.
+// A naive mount would expose every embedded asset's name at GET /static/,
+// which is a small fingerprint signal we'd rather not give scanners.
+func TestSPA_DirectoryListingRefused(t *testing.T) {
+	h := newHarnessWithSPA(t)
+	for _, path := range []string{"/static/", "/static/somedir/"} {
+		t.Run(path, func(t *testing.T) {
+			resp, body := h.do("GET", path, "", nil)
+			assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+				"%s must 404 (no directory listing)", path)
+			assert.NotContains(t, string(body), "<a href=",
+				"response body must not contain an HTML directory index")
+		})
+	}
+}
+
+// TestSPA_IndexCarriesAssetVersion verifies the cache-busting wiring:
+// every /static/* URL in the rendered index.html should carry a ?v=…
+// query so a deploy reliably invalidates browser caches even though
+// the static file server itself sets no Cache-Control on assets.
+func TestSPA_IndexCarriesAssetVersion(t *testing.T) {
+	h := newHarnessWithSPA(t)
+	resp, body := h.do("GET", "/", "", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	for _, asset := range []string{"app.js", "auth.js", "api.js", "editor.js", "style.css"} {
+		assert.Regexp(t, `/static/`+asset+`\?v=\w+`, string(body),
+			"%s must be referenced with a ?v=… cache-buster", asset)
+	}
+}
+
 // --- OpenAPI ---
 
 func TestOpenAPI_YAML_Unauth(t *testing.T) {

--- a/internal/ui-config/embed.go
+++ b/internal/ui-config/embed.go
@@ -1,0 +1,23 @@
+// Package uiconfig holds the embedded SPA bundle (HTML + JS + CSS) for the
+// config service's admin UI. The SPA authenticates against identity via
+// the OAuth Authorization Code + PKCE flow, stores tokens in localStorage,
+// and calls the existing /api/v1/config/* endpoints with a Bearer header.
+//
+// See examples/spa-demo for the auth pattern this UI follows. There is no
+// server-side session, no CSRF middleware, and no cookie crypto — the
+// config service stays purely API-driven and serves these files
+// statically.
+package uiconfig
+
+import (
+	"embed"
+	"strconv"
+	"time"
+)
+
+//go:embed static
+var StaticFS embed.FS
+
+// AssetVersion is set at startup; append as ?v=… in templates so a fresh
+// deploy invalidates browser caches.
+var AssetVersion = strconv.FormatInt(time.Now().Unix(), 36)

--- a/internal/ui-config/static/api.js
+++ b/internal/ui-config/static/api.js
@@ -1,0 +1,47 @@
+// api.js — thin wrapper around the config service's /api/v1/config/*.
+// Uses Auth.authedFetch so 401s automatically trigger refresh-and-retry.
+
+window.ConfigAPI = (function () {
+  'use strict';
+
+  function api(path) { return '/api/v1/config' + path; }
+
+  async function readJSON(resp) {
+    const txt = await resp.text();
+    try { return txt ? JSON.parse(txt) : null; }
+    catch (_) { return txt; }
+  }
+
+  async function check(resp) {
+    if (resp.ok) return readJSON(resp);
+    const body = await readJSON(resp);
+    const err = (body && body.message) || (body && body.error) || ('HTTP ' + resp.status);
+    const e = new Error(err);
+    e.status = resp.status;
+    e.body   = body;
+    throw e;
+  }
+
+  return {
+    list:     async ()             => check(await Auth.authedFetch(api(''))),
+    get:      async (ns)           => check(await Auth.authedFetch(api('/' + encodeURIComponent(ns)))),
+    put:      async (ns, doc) => check(await Auth.authedFetch(api('/' + encodeURIComponent(ns)), {
+      method:  'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body:    typeof doc === 'string' ? doc : JSON.stringify(doc),
+    })),
+    create:   async (input)        => check(await Auth.authedFetch(api('/namespaces'), {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(input),
+    })),
+    updateACL: async (ns, acl) => check(await Auth.authedFetch(api('/namespaces/' + encodeURIComponent(ns)), {
+      method:  'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify(acl),
+    })),
+    delete:   async (ns) => check(await Auth.authedFetch(api('/' + encodeURIComponent(ns)), {
+      method: 'DELETE',
+    })),
+  };
+})();

--- a/internal/ui-config/static/app.js
+++ b/internal/ui-config/static/app.js
@@ -341,15 +341,27 @@
     // Display username if we have a token (cheap call to identity).
     if (Auth.isAuthenticated()) {
       try {
-        // We could decode the JWT for the username, but a fetch keeps things simple
-        // and exercises the auth path on every refresh.
-        const cfg = await fetch('/spa-config.json').then(r => r.json());
+        // Reuse the cached bootstrap config rather than refetching
+        // /spa-config.json. We could also decode the JWT for the
+        // username, but a network call exercises the auth path on
+        // every page load and surfaces a stale token immediately.
+        const cfg = Auth.getConfig();
         const meResp = await Auth.authedFetch(cfg.identity_url + '/api/v1/auth/me');
         if (meResp.ok) {
           const me = await meResp.json();
           USER_INFO.textContent = me.username + ' (' + me.role + ')';
         }
-      } catch (_) { /* non-fatal */ }
+      } catch (e) {
+        // 'session expired' from authedFetch means refresh failed; we
+        // must clear tokens so route() will land on the login view
+        // instead of leaving the UI half-authed (logout-button visible
+        // but no real session).
+        if (e && (e.message === 'session expired' || e.message === 'not authenticated')) {
+          Auth.clearTokens();
+        }
+        // Other errors (network blip, identity 5xx) are non-fatal:
+        // the username just won't render.
+      }
     }
 
     await route();

--- a/internal/ui-config/static/app.js
+++ b/internal/ui-config/static/app.js
@@ -1,0 +1,357 @@
+// app.js — config admin SPA bootstrap, hash router, and CRUD views.
+//
+// Routes (hash-based so the SPA works without server-side rewrite rules):
+//
+//   #/             → list of namespaces visible to the caller
+//   #/new          → create a new namespace
+//   #/edit/{ns}    → view + edit a namespace's document and ACL
+//
+// Everything renders into <main id="app">. Each handler returns an
+// element that the router mounts in place of the previous view.
+
+(function () {
+  'use strict';
+
+  const APP        = document.getElementById('app');
+  const USER_INFO  = document.getElementById('user-info');
+  const LOGOUT_BTN = document.getElementById('logout-btn');
+  const TOAST      = document.getElementById('toast');
+
+  // ── helpers ────────────────────────────────────────────────────────
+  function el(tag, attrs, children) {
+    const e = document.createElement(tag);
+    if (attrs) for (const k in attrs) {
+      if (k === 'class')      e.className = attrs[k];
+      else if (k === 'text')  e.textContent = attrs[k];
+      else if (k === 'html')  e.innerHTML = attrs[k];
+      else if (k === 'on')    for (const ev in attrs.on) e.addEventListener(ev, attrs.on[ev]);
+      else if (attrs[k] === false) { /* omit */ }
+      else if (attrs[k] === true)  e.setAttribute(k, '');
+      else                         e.setAttribute(k, attrs[k]);
+    }
+    if (children) children.forEach(c => c && e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c));
+    return e;
+  }
+  function clear(node) { while (node.firstChild) node.removeChild(node.firstChild); }
+  function mount(node) { clear(APP); APP.appendChild(node); }
+
+  let toastT;
+  function toast(msg, kind) {
+    TOAST.textContent = msg;
+    TOAST.className = kind === 'error' ? 'error' : '';
+    TOAST.hidden = false;
+    clearTimeout(toastT);
+    toastT = setTimeout(() => { TOAST.hidden = true; }, 3500);
+  }
+
+  function fmtTime(s) {
+    if (!s) return '';
+    const d = new Date(s);
+    if (isNaN(d.getTime())) return s;
+    return d.toLocaleString();
+  }
+
+  function badge(role) {
+    return el('span', { class: 'badge ' + role, text: role });
+  }
+
+  // ── views ──────────────────────────────────────────────────────────
+
+  // Anonymous landing — only shown if no token in localStorage.
+  function viewLogin() {
+    const btn = el('button', { text: 'Sign in with Identity', on: { click: () => Auth.startLogin() } });
+    return el('div', null, [
+      el('h1', { text: 'Config Admin' }),
+      el('p', { text: 'Sign in via your identity service to manage homelab config namespaces.' }),
+      el('div', { class: 'button-row' }, [btn]),
+    ]);
+  }
+
+  async function viewList() {
+    const root = el('div');
+    root.appendChild(el('div', { class: 'button-row' }, [
+      el('h1', { text: 'Namespaces' }),
+    ]));
+    root.appendChild(el('div', { class: 'button-row right' }, [
+      el('a', { class: 'btn', href: '#/new', text: 'New namespace' }),
+    ]));
+
+    const status = el('div', { class: 'loading', text: 'Loading…' });
+    root.appendChild(status);
+
+    try {
+      const items = await ConfigAPI.list();
+      root.removeChild(status);
+      if (!items || items.length === 0) {
+        root.appendChild(el('div', { class: 'empty', text: 'No namespaces yet.' }));
+        return root;
+      }
+      const ul = el('ul', { class: 'namespace-list' });
+      for (const ns of items) {
+        const left = el('div', null, [
+          el('a', { class: 'name', href: '#/edit/' + encodeURIComponent(ns.name), text: ns.name }),
+          el('div', { class: 'meta', text: 'updated ' + fmtTime(ns.updated_at) }),
+        ]);
+        const right = el('div', { class: 'badges' }, [
+          el('span', { class: 'meta', text: 'read' }), badge(ns.read_role),
+          el('span', { class: 'meta', text: 'write' }), badge(ns.write_role),
+        ]);
+        ul.appendChild(el('li', null, [left, right]));
+      }
+      root.appendChild(ul);
+    } catch (e) {
+      root.removeChild(status);
+      root.appendChild(el('div', { class: 'empty', text: 'Failed to load: ' + e.message }));
+    }
+    return root;
+  }
+
+  function roleSelect(name, value) {
+    const sel = el('select', { name: name });
+    for (const role of ['admin', 'user']) {
+      const opt = el('option', { value: role, text: role });
+      if (value === role) opt.selected = true;
+      sel.appendChild(opt);
+    }
+    return sel;
+  }
+
+  function viewNew() {
+    const root = el('div');
+    root.appendChild(el('h1', { text: 'New namespace' }));
+    root.appendChild(el('p', { class: 'form-help', text: 'Names must match ^[a-z0-9_-]{1,64}$. Documents must be JSON objects (≤ 64KB).' }));
+
+    const nameInp = el('input', { type: 'text', name: 'name', placeholder: 'e.g. mqtt_topics', autofocus: true });
+    const readSel = roleSelect('read_role', 'admin');
+    const writeSel = roleSelect('write_role', 'admin');
+
+    const editorHost = el('div');
+    const editor = JSONEditor.create(editorHost, { value: '{}\n' });
+
+    const errBox = el('div', { class: 'form-error' });
+    const submitBtn = el('button', { type: 'submit', text: 'Create' });
+    const cancelBtn = el('a', { class: 'btn btn-secondary', href: '#/', text: 'Cancel' });
+
+    const form = el('form', {
+      on: { submit: async (e) => {
+        e.preventDefault();
+        errBox.textContent = '';
+        let parsed;
+        try { parsed = editor.getValueOrThrow(); }
+        catch (err) { errBox.textContent = err.message; return; }
+        submitBtn.disabled = true;
+        try {
+          await ConfigAPI.create({
+            name:       nameInp.value.trim(),
+            read_role:  readSel.value,
+            write_role: writeSel.value,
+            document:   parsed.obj,
+          });
+          toast('Namespace created');
+          location.hash = '#/edit/' + encodeURIComponent(nameInp.value.trim());
+        } catch (err) {
+          errBox.textContent = err.message;
+        } finally {
+          submitBtn.disabled = false;
+        }
+      } },
+    });
+    form.appendChild(el('label', { text: 'Name', for: 'name' }));
+    form.appendChild(nameInp);
+    form.appendChild(el('label', { text: 'Read role' }));
+    form.appendChild(readSel);
+    form.appendChild(el('label', { text: 'Write role (must satisfy read role)' }));
+    form.appendChild(writeSel);
+    form.appendChild(el('label', { text: 'Initial document' }));
+    form.appendChild(editorHost);
+    form.appendChild(errBox);
+    form.appendChild(el('div', { class: 'button-row' }, [submitBtn, cancelBtn]));
+    root.appendChild(form);
+    return root;
+  }
+
+  async function viewEdit(name) {
+    const root = el('div');
+    root.appendChild(el('h1', { text: name }));
+
+    const status = el('div', { class: 'loading', text: 'Loading…' });
+    root.appendChild(status);
+
+    let doc;
+    try {
+      doc = await ConfigAPI.get(name);
+    } catch (e) {
+      root.removeChild(status);
+      if (e.status === 404) {
+        root.appendChild(el('div', { class: 'empty', text: 'Namespace not found (or you do not have read access).' }));
+        return root;
+      }
+      root.appendChild(el('div', { class: 'empty', text: 'Failed to load: ' + e.message }));
+      return root;
+    }
+    root.removeChild(status);
+
+    // List endpoint also returns ACL; fetch the full list once to find this row.
+    let aclRow = null;
+    try {
+      const list = await ConfigAPI.list();
+      aclRow = (list || []).find(r => r.name === name) || null;
+    } catch (_) { /* non-fatal */ }
+
+    // ─ Document edit ─
+    root.appendChild(el('h2', { text: 'Document' }));
+    const editorHost = el('div');
+    const editor = JSONEditor.create(editorHost, { value: JSON.stringify(doc, null, 2) + '\n' });
+    root.appendChild(editorHost);
+
+    const saveBtn   = el('button', { type: 'button', text: 'Save' });
+    const revertBtn = el('button', { type: 'button', class: 'btn-secondary', text: 'Revert' });
+    const docErr    = el('div', { class: 'form-error' });
+
+    saveBtn.addEventListener('click', async () => {
+      docErr.textContent = '';
+      let parsed;
+      try { parsed = editor.getValueOrThrow(); }
+      catch (err) { docErr.textContent = err.message; return; }
+      saveBtn.disabled = true;
+      try {
+        const r = await ConfigAPI.put(name, parsed.source);
+        toast(r && r.changed === false ? 'No change' : 'Saved');
+      } catch (err) {
+        docErr.textContent = err.message;
+        toast('Save failed: ' + err.message, 'error');
+      } finally {
+        saveBtn.disabled = false;
+      }
+    });
+    revertBtn.addEventListener('click', async () => {
+      try {
+        const fresh = await ConfigAPI.get(name);
+        editor.setValue(JSON.stringify(fresh, null, 2) + '\n');
+        toast('Reverted to stored version');
+      } catch (err) {
+        toast('Revert failed: ' + err.message, 'error');
+      }
+    });
+    root.appendChild(el('div', { class: 'button-row' }, [saveBtn, revertBtn]));
+    root.appendChild(docErr);
+
+    // ─ ACL ─
+    root.appendChild(el('h2', { text: 'Access control' }));
+    const aclReadSel  = roleSelect('read_role',  aclRow ? aclRow.read_role  : 'admin');
+    const aclWriteSel = roleSelect('write_role', aclRow ? aclRow.write_role : 'admin');
+    const aclErr = el('div', { class: 'form-error' });
+    const aclBtn = el('button', { type: 'button', text: 'Update ACL' });
+    aclBtn.addEventListener('click', async () => {
+      aclErr.textContent = '';
+      aclBtn.disabled = true;
+      try {
+        await ConfigAPI.updateACL(name, { read_role: aclReadSel.value, write_role: aclWriteSel.value });
+        toast('ACL updated');
+      } catch (err) {
+        aclErr.textContent = err.message;
+        toast('ACL update failed: ' + err.message, 'error');
+      } finally {
+        aclBtn.disabled = false;
+      }
+    });
+    const aclGrid = el('div', { class: 'card' }, [
+      el('label', { text: 'Read role' }), aclReadSel,
+      el('label', { text: 'Write role (must satisfy read role)' }), aclWriteSel,
+      el('div', { class: 'button-row' }, [aclBtn]),
+      aclErr,
+    ]);
+    root.appendChild(aclGrid);
+
+    // ─ Delete ─
+    root.appendChild(el('h2', { text: 'Danger zone' }));
+    const deleteBtn = el('button', { type: 'button', class: 'btn-danger', text: 'Delete namespace' });
+    deleteBtn.addEventListener('click', async () => {
+      if (!confirm('Delete namespace ' + name + '? This cannot be undone.')) return;
+      try {
+        await ConfigAPI.delete(name);
+        toast('Deleted');
+        location.hash = '#/';
+      } catch (err) {
+        toast('Delete failed: ' + err.message, 'error');
+      }
+    });
+    root.appendChild(el('div', { class: 'card' }, [
+      el('p', { class: 'form-help', text: 'Deleting a namespace is permanent and triggers a backup of the post-delete state.' }),
+      el('div', { class: 'button-row' }, [deleteBtn]),
+    ]));
+
+    return root;
+  }
+
+  // ── router ─────────────────────────────────────────────────────────
+  async function route() {
+    if (!Auth.isAuthenticated()) {
+      USER_INFO.textContent = '';
+      LOGOUT_BTN.hidden = true;
+      mount(viewLogin());
+      return;
+    }
+    LOGOUT_BTN.hidden = false;
+
+    const hash = location.hash || '#/';
+    let view;
+    try {
+      if (hash === '#/' || hash === '')        view = await viewList();
+      else if (hash === '#/new')               view = viewNew();
+      else if (hash.startsWith('#/edit/'))     view = await viewEdit(decodeURIComponent(hash.slice('#/edit/'.length)));
+      else                                     view = el('div', { class: 'empty', text: 'Unknown route. ' }, [
+        el('a', { href: '#/', text: 'Back' })
+      ]);
+      mount(view);
+    } catch (e) {
+      if (e.message === 'session expired' || e.message === 'not authenticated') {
+        Auth.clearTokens();
+        await route();
+        return;
+      }
+      mount(el('div', { class: 'empty', text: 'Error: ' + e.message }));
+    }
+  }
+
+  // ── bootstrap ──────────────────────────────────────────────────────
+  (async function init() {
+    LOGOUT_BTN.addEventListener('click', async () => {
+      await Auth.logout();
+      location.hash = '#/';
+      route();
+    });
+    window.addEventListener('hashchange', route);
+
+    try {
+      await Auth.bootstrap();
+    } catch (e) {
+      mount(el('div', { class: 'empty', text: 'Cannot reach config service: ' + e.message }));
+      return;
+    }
+
+    try {
+      const handled = await Auth.maybeHandleCallback();
+      if (handled) toast('Signed in');
+    } catch (e) {
+      Auth.clearTokens();
+      toast(e.message, 'error');
+    }
+
+    // Display username if we have a token (cheap call to identity).
+    if (Auth.isAuthenticated()) {
+      try {
+        // We could decode the JWT for the username, but a fetch keeps things simple
+        // and exercises the auth path on every refresh.
+        const cfg = await fetch('/spa-config.json').then(r => r.json());
+        const meResp = await Auth.authedFetch(cfg.identity_url + '/api/v1/auth/me');
+        if (meResp.ok) {
+          const me = await meResp.json();
+          USER_INFO.textContent = me.username + ' (' + me.role + ')';
+        }
+      } catch (_) { /* non-fatal */ }
+    }
+
+    await route();
+  })();
+})();

--- a/internal/ui-config/static/auth.js
+++ b/internal/ui-config/static/auth.js
@@ -1,0 +1,197 @@
+// auth.js — OAuth Authorization Code + PKCE flow against identity.
+//
+// State management:
+//   - access_token, refresh_token, token_expires_at  in localStorage
+//   - pkce_verifier, oauth_state                      in sessionStorage
+//     (cleared on tab close so a half-finished login doesn't leak across
+//      browser sessions)
+//
+// Threat model: an XSS on this origin can read tokens from localStorage.
+// We mitigate by serving a strict CSP from the server (script-src 'self'
+// only) and by not embedding any third-party scripts. For the homelab
+// admin UI threat model this is acceptable; a SaaS would prefer
+// HttpOnly cookies + a server-side session.
+
+window.Auth = (function () {
+  'use strict';
+
+  let CONFIG = null;          // populated in bootstrap()
+  let refreshInFlight = null; // Promise; coalesces concurrent refreshes
+
+  // ── PKCE helpers ───────────────────────────────────────────────────
+  function randomString(bytes) {
+    const buf = new Uint8Array(bytes);
+    crypto.getRandomValues(buf);
+    return base64url(buf);
+  }
+  function base64url(buf) {
+    return btoa(String.fromCharCode(...buf))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  async function pkceChallenge(verifier) {
+    const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+    return base64url(new Uint8Array(hash));
+  }
+
+  // ── Token storage ──────────────────────────────────────────────────
+  function getAccessToken()  { return localStorage.getItem('access_token'); }
+  function getRefreshToken() { return localStorage.getItem('refresh_token'); }
+  function getExpiresAt()    { return parseInt(localStorage.getItem('token_expires_at') || '0', 10); }
+  function saveTokens(t) {
+    localStorage.setItem('access_token',     t.access_token);
+    localStorage.setItem('refresh_token',    t.refresh_token);
+    localStorage.setItem('token_expires_at', Date.now() + t.expires_in * 1000);
+  }
+  function clearTokens() {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('refresh_token');
+    localStorage.removeItem('token_expires_at');
+    sessionStorage.removeItem('pkce_verifier');
+    sessionStorage.removeItem('oauth_state');
+  }
+  function isAuthenticated() {
+    return !!getAccessToken();
+  }
+
+  // ── Login (redirect to identity) ───────────────────────────────────
+  async function startLogin() {
+    if (!CONFIG) throw new Error('Auth not bootstrapped');
+    const verifier  = randomString(32);
+    const state     = randomString(16);
+    const challenge = await pkceChallenge(verifier);
+
+    sessionStorage.setItem('pkce_verifier', verifier);
+    sessionStorage.setItem('oauth_state',   state);
+
+    const params = new URLSearchParams({
+      response_type:         'code',
+      client_id:             CONFIG.client_id,
+      redirect_uri:          location.origin + '/',
+      code_challenge:        challenge,
+      code_challenge_method: 'S256',
+      state:                 state,
+    });
+    location.href = CONFIG.identity_url + '/oauth/authorize?' + params;
+  }
+
+  // ── Callback (exchange code for tokens) ────────────────────────────
+  // Returns true if a callback was handled; false if there was no code in the URL.
+  async function maybeHandleCallback() {
+    const params = new URLSearchParams(location.search);
+    const code   = params.get('code');
+    const state  = params.get('state');
+    if (!code || !state) return false;
+
+    const expected = sessionStorage.getItem('oauth_state');
+    if (state !== expected) {
+      throw new Error('OAuth state mismatch — possible CSRF; aborting');
+    }
+    const verifier = sessionStorage.getItem('pkce_verifier');
+    if (!verifier) {
+      throw new Error('PKCE verifier missing — start login again');
+    }
+
+    const resp = await fetch(CONFIG.identity_url + '/oauth/token', {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type:    'authorization_code',
+        client_id:     CONFIG.client_id,
+        code, redirect_uri: location.origin + '/',
+        code_verifier: verifier,
+      }),
+    });
+    const body = await resp.json().catch(() => ({}));
+    if (!resp.ok) {
+      throw new Error('Token exchange failed: ' + (body.error || resp.status));
+    }
+    saveTokens(body);
+    sessionStorage.removeItem('pkce_verifier');
+    sessionStorage.removeItem('oauth_state');
+
+    // Strip ?code & ?state from the URL so a refresh doesn't replay.
+    history.replaceState(null, '', location.pathname + location.hash);
+    return true;
+  }
+
+  // ── Refresh ────────────────────────────────────────────────────────
+  // Coalesces concurrent calls so 5 simultaneous 401s only kick off one refresh.
+  function refresh() {
+    if (refreshInFlight) return refreshInFlight;
+    refreshInFlight = (async () => {
+      const rt = getRefreshToken();
+      if (!rt) return false;
+      const resp = await fetch(CONFIG.identity_url + '/oauth/token', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type:    'refresh_token',
+          refresh_token: rt,
+        }),
+      });
+      if (!resp.ok) return false;
+      saveTokens(await resp.json());
+      return true;
+    })().finally(() => { refreshInFlight = null; });
+    return refreshInFlight;
+  }
+
+  // ── Authed fetch wrapper ───────────────────────────────────────────
+  // Adds Authorization header. On 401, tries refresh-and-retry once.
+  async function authedFetch(url, opts = {}) {
+    const tok = getAccessToken();
+    if (!tok) throw new Error('not authenticated');
+    opts.headers = Object.assign({}, opts.headers, { Authorization: 'Bearer ' + tok });
+    let resp = await fetch(url, opts);
+    if (resp.status !== 401) return resp;
+
+    const ok = await refresh();
+    if (!ok) {
+      clearTokens();
+      throw new Error('session expired');
+    }
+    opts.headers.Authorization = 'Bearer ' + getAccessToken();
+    return fetch(url, opts);
+  }
+
+  // ── Logout ─────────────────────────────────────────────────────────
+  // Best-effort revocation on identity, then clear local state.
+  async function logout() {
+    const rt = getRefreshToken();
+    if (rt) {
+      try {
+        await fetch(CONFIG.identity_url + '/api/v1/auth/logout', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body:    JSON.stringify({ refresh_token: rt }),
+        });
+      } catch (_) { /* ignore — local clear is the source of truth */ }
+    }
+    clearTokens();
+  }
+
+  // ── Bootstrap ──────────────────────────────────────────────────────
+  // Must be called first. Returns the resolved config so callers can
+  // pass it on to the API layer.
+  async function bootstrap() {
+    const resp = await fetch('/spa-config.json');
+    if (!resp.ok) throw new Error('failed to load /spa-config.json: ' + resp.status);
+    CONFIG = await resp.json();
+    if (!CONFIG.identity_url || !CONFIG.client_id) {
+      throw new Error('SPA config missing identity_url or client_id');
+    }
+    return CONFIG;
+  }
+
+  return {
+    bootstrap,
+    startLogin,
+    maybeHandleCallback,
+    refresh,
+    authedFetch,
+    logout,
+    isAuthenticated,
+    getAccessToken,
+    clearTokens,
+  };
+})();

--- a/internal/ui-config/static/auth.js
+++ b/internal/ui-config/static/auth.js
@@ -38,6 +38,23 @@ window.Auth = (function () {
   function getRefreshToken() { return localStorage.getItem('refresh_token'); }
   function getExpiresAt()    { return parseInt(localStorage.getItem('token_expires_at') || '0', 10); }
   function saveTokens(t) {
+    // Validate the response shape before persisting. A malformed identity
+    // response (or a misconfigured proxy stripping fields) would otherwise
+    // leave us with `localStorage.setItem('refresh_token', undefined)` —
+    // which writes the literal string "undefined" — and wedge the SPA
+    // permanently with no path back to a clean re-login.
+    if (!t || typeof t !== 'object') {
+      throw new Error('token response is not an object');
+    }
+    if (typeof t.access_token !== 'string' || !t.access_token) {
+      throw new Error('token response missing access_token');
+    }
+    if (typeof t.refresh_token !== 'string' || !t.refresh_token) {
+      throw new Error('token response missing refresh_token');
+    }
+    if (typeof t.expires_in !== 'number' || !(t.expires_in > 0)) {
+      throw new Error('token response missing or invalid expires_in');
+    }
     localStorage.setItem('access_token',     t.access_token);
     localStorage.setItem('refresh_token',    t.refresh_token);
     localStorage.setItem('token_expires_at', Date.now() + t.expires_in * 1000);
@@ -116,21 +133,34 @@ window.Auth = (function () {
 
   // ── Refresh ────────────────────────────────────────────────────────
   // Coalesces concurrent calls so 5 simultaneous 401s only kick off one refresh.
+  // Returns true on success, false on any failure (network, server error,
+  // malformed response). Network failures are intentionally treated as
+  // refresh-failures so the SPA can route to the login screen instead of
+  // throwing an unhandled error from a transient blip.
   function refresh() {
     if (refreshInFlight) return refreshInFlight;
     refreshInFlight = (async () => {
       const rt = getRefreshToken();
       if (!rt) return false;
-      const resp = await fetch(CONFIG.identity_url + '/oauth/token', {
-        method:  'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          grant_type:    'refresh_token',
-          refresh_token: rt,
-        }),
-      });
+      let resp;
+      try {
+        resp = await fetch(CONFIG.identity_url + '/oauth/token', {
+          method:  'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type:    'refresh_token',
+            refresh_token: rt,
+          }),
+        });
+      } catch (_) {
+        return false; // network failure — caller will treat as session expired
+      }
       if (!resp.ok) return false;
-      saveTokens(await resp.json());
+      let body;
+      try { body = await resp.json(); }
+      catch (_) { return false; }
+      try { saveTokens(body); }
+      catch (_) { return false; }
       return true;
     })().finally(() => { refreshInFlight = null; });
     return refreshInFlight;
@@ -156,16 +186,24 @@ window.Auth = (function () {
 
   // ── Logout ─────────────────────────────────────────────────────────
   // Best-effort revocation on identity, then clear local state.
+  // Identity's /api/v1/auth/logout is auth-gated — it identifies the
+  // session via the access token and revokes the supplied refresh
+  // token (or the whole family if none is supplied). Without the
+  // Bearer header we'd 401 every time and never actually revoke.
   async function logout() {
-    const rt = getRefreshToken();
-    if (rt) {
+    const tok = getAccessToken();
+    const rt  = getRefreshToken();
+    if (tok && rt) {
       try {
         await fetch(CONFIG.identity_url + '/api/v1/auth/logout', {
           method:  'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body:    JSON.stringify({ refresh_token: rt }),
+          headers: {
+            'Content-Type':  'application/json',
+            'Authorization': 'Bearer ' + tok,
+          },
+          body: JSON.stringify({ refresh_token: rt }),
         });
-      } catch (_) { /* ignore — local clear is the source of truth */ }
+      } catch (_) { /* network failure — local clear is the source of truth */ }
     }
     clearTokens();
   }
@@ -183,8 +221,16 @@ window.Auth = (function () {
     return CONFIG;
   }
 
+  // getConfig returns the cached bootstrap config so callers (e.g. the
+  // username-display path) don't need to refetch /spa-config.json.
+  function getConfig() {
+    if (!CONFIG) throw new Error('Auth not bootstrapped');
+    return CONFIG;
+  }
+
   return {
     bootstrap,
+    getConfig,
     startLogin,
     maybeHandleCallback,
     refresh,

--- a/internal/ui-config/static/editor.js
+++ b/internal/ui-config/static/editor.js
@@ -1,0 +1,129 @@
+// editor.js — pimped <textarea> JSON editor.
+//
+// Affordances:
+//   - Monospace styling (set in CSS)
+//   - Tab inserts 2 spaces (instead of changing focus)
+//   - Format button: pretty-prints valid JSON
+//   - Live validation: parses on input, shows the parser's error message
+//     and highlights the offending line in the toolbar status
+//   - Validate-on-save guard via getValueOrThrow()
+//
+// Deliberately NOT a full editor — no syntax highlighting, no folding.
+// CodeMirror is a follow-up if homelab admins ask for it.
+
+window.JSONEditor = (function () {
+  'use strict';
+
+  function el(tag, attrs, children) {
+    const e = document.createElement(tag);
+    if (attrs) for (const k in attrs) {
+      if (k === 'class')      e.className = attrs[k];
+      else if (k === 'text')  e.textContent = attrs[k];
+      else                    e.setAttribute(k, attrs[k]);
+    }
+    if (children) children.forEach(c => e.appendChild(c));
+    return e;
+  }
+
+  function deriveLineColumn(src, byteOffset) {
+    let line = 1, col = 1;
+    for (let i = 0; i < byteOffset && i < src.length; i++) {
+      if (src.charCodeAt(i) === 10) { line++; col = 1; }
+      else col++;
+    }
+    return { line, col };
+  }
+
+  // Parses error messages like "Unexpected token ',' ... at position 42"
+  // (V8/Chromium) or with a position via SyntaxError stack on Firefox.
+  // Falls back to the raw message if no position info is available.
+  function annotate(src, err) {
+    const m = String(err.message || '').match(/position (\d+)/);
+    if (m) {
+      const { line, col } = deriveLineColumn(src, parseInt(m[1], 10));
+      return `JSON parse error at line ${line}, col ${col}: ${err.message}`;
+    }
+    return 'JSON parse error: ' + err.message;
+  }
+
+  function create(host, opts) {
+    opts = opts || {};
+    host.classList.add('editor-wrap');
+
+    // Toolbar
+    const status = el('span', { class: 'status' });
+    const formatBtn = el('button', { type: 'button', class: 'btn-secondary', text: 'Format' });
+    const tools = el('div', { class: 'lhs' }, [formatBtn]);
+    const toolbar = el('div', { class: 'editor-toolbar' }, [tools, status]);
+
+    // Textarea
+    const ta = el('textarea', { class: 'editor', spellcheck: 'false', autocomplete: 'off', autocorrect: 'off', autocapitalize: 'off' });
+    if (opts.value !== undefined) ta.value = opts.value;
+
+    host.appendChild(toolbar);
+    host.appendChild(ta);
+
+    function setStatus(text, kind) {
+      status.textContent = text;
+      status.className = 'status' + (kind ? ' ' + kind : '');
+    }
+
+    function validate() {
+      if (!ta.value.trim()) { setStatus('empty'); return null; }
+      try {
+        JSON.parse(ta.value);
+        setStatus('valid JSON', 'ok');
+        return true;
+      } catch (e) {
+        setStatus(annotate(ta.value, e), 'error');
+        return false;
+      }
+    }
+
+    function format() {
+      try {
+        const obj = JSON.parse(ta.value || '{}');
+        ta.value = JSON.stringify(obj, null, 2) + '\n';
+        validate();
+      } catch (e) {
+        setStatus(annotate(ta.value, e), 'error');
+      }
+    }
+
+    // Tab inserts 2 spaces.
+    ta.addEventListener('keydown', (e) => {
+      if (e.key === 'Tab' && !e.shiftKey) {
+        e.preventDefault();
+        const start = ta.selectionStart, end = ta.selectionEnd;
+        ta.value = ta.value.slice(0, start) + '  ' + ta.value.slice(end);
+        ta.selectionStart = ta.selectionEnd = start + 2;
+      }
+    });
+
+    ta.addEventListener('input', validate);
+    formatBtn.addEventListener('click', format);
+
+    // Initial status
+    validate();
+
+    return {
+      element: ta,
+      getValue: () => ta.value,
+      // Throws on invalid JSON; returns the parsed object plus the source string.
+      getValueOrThrow: () => {
+        const val = ta.value.trim() || '{}';
+        const obj = JSON.parse(val);
+        if (Object.prototype.toString.call(obj) !== '[object Object]') {
+          throw new Error('document must be a JSON object (got ' + (Array.isArray(obj) ? 'array' : typeof obj) + ')');
+        }
+        return { obj, source: val };
+      },
+      setValue: (v) => { ta.value = v; validate(); },
+      isValid:  validate,
+      format,
+      focus:    () => ta.focus(),
+    };
+  }
+
+  return { create };
+})();

--- a/internal/ui-config/static/index.html
+++ b/internal/ui-config/static/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Config Admin</title>
-<link rel="stylesheet" href="/static/style.css">
+<link rel="stylesheet" href="/static/style.css?v={{.AssetVer}}">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='7' fill='%2302aaa2'/></svg>">
 </head>
 <body>
@@ -23,9 +23,9 @@
 
 <div id="toast" hidden></div>
 
-<script src="/static/auth.js" defer></script>
-<script src="/static/api.js" defer></script>
-<script src="/static/editor.js" defer></script>
-<script src="/static/app.js" defer></script>
+<script src="/static/auth.js?v={{.AssetVer}}" defer></script>
+<script src="/static/api.js?v={{.AssetVer}}" defer></script>
+<script src="/static/editor.js?v={{.AssetVer}}" defer></script>
+<script src="/static/app.js?v={{.AssetVer}}" defer></script>
 </body>
 </html>

--- a/internal/ui-config/static/index.html
+++ b/internal/ui-config/static/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Config Admin</title>
+<link rel="stylesheet" href="/static/style.css">
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='7' fill='%2302aaa2'/></svg>">
+</head>
+<body>
+
+<nav>
+  <a class="brand" href="#/">Config</a>
+  <div class="links">
+    <span id="user-info"></span>
+    <button id="logout-btn" class="btn-link" hidden>Logout</button>
+  </div>
+</nav>
+
+<main class="container">
+  <div id="app"></div>
+</main>
+
+<div id="toast" hidden></div>
+
+<script src="/static/auth.js" defer></script>
+<script src="/static/api.js" defer></script>
+<script src="/static/editor.js" defer></script>
+<script src="/static/app.js" defer></script>
+</body>
+</html>

--- a/internal/ui-config/static/style.css
+++ b/internal/ui-config/static/style.css
@@ -1,0 +1,228 @@
+/* Config admin SPA — minimal stylesheet, mirrors identity's visual language */
+
+:root {
+    --brand:       #02aaa2;
+    --brand-hover: #028f88;
+    --brand-focus: rgba(2, 170, 162, 0.3);
+    --danger:      #d63031;
+    --danger-hover:#b71c1c;
+    --text:        #1a1a2e;
+    --text-muted:  #6c757d;
+    --bg:          #fff;
+    --bg-surface:  #f8f9fa;
+    --bg-code:     #f4f4f4;
+    --border:      #dee2e6;
+    --radius:      6px;
+    --error:       #d63031;
+    --success:     #198754;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text:       #e0e0e0;
+        --text-muted: #9e9e9e;
+        --bg:         #1a1a2e;
+        --bg-surface: #222240;
+        --bg-code:    #2a2a4a;
+        --border:     #3a3a5c;
+    }
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.6;
+    color: var(--text);
+    background: var(--bg);
+}
+
+.container { max-width: 960px; margin: 0 auto; padding: 0 1.5rem 3rem; }
+
+/* Typography */
+h1, h2, h3 { margin-bottom: 0.75rem; font-weight: 600; }
+h1 { font-size: 1.7rem; }
+h2 { font-size: 1.4rem; margin-top: 1.25rem; }
+h3 { font-size: 1.1rem; }
+p  { margin-bottom: 1rem; }
+a  { color: var(--brand); text-decoration: none; }
+a:hover { color: var(--brand-hover); text-decoration: underline; }
+small { color: var(--text-muted); font-size: 0.85em; }
+code { background: var(--bg-code); padding: 0.15em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+/* Nav */
+nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+nav .brand { font-weight: 700; font-size: 1.1rem; color: var(--brand); }
+nav .brand:hover { text-decoration: none; }
+nav .links { display: flex; gap: 1rem; align-items: center; color: var(--text-muted); font-size: 0.9rem; }
+
+/* Buttons */
+button, .btn {
+    display: inline-block;
+    padding: 0.5rem 1.1rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+    border-radius: var(--radius);
+    cursor: pointer;
+    text-decoration: none;
+    line-height: 1.5;
+    transition: background 0.15s, border-color 0.15s;
+    background: var(--brand);
+    color: #fff;
+    font-family: inherit;
+}
+button:hover, .btn:hover { background: var(--brand-hover); }
+button:focus, .btn:focus { outline: 3px solid var(--brand-focus); outline-offset: 1px; }
+button:disabled, .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+button.btn-secondary {
+    background: var(--bg-surface);
+    color: var(--text);
+    border-color: var(--border);
+}
+button.btn-secondary:hover { background: var(--border); }
+
+button.btn-danger { background: var(--danger); }
+button.btn-danger:hover { background: var(--danger-hover); }
+
+button.btn-link {
+    background: none;
+    color: var(--text-muted);
+    padding: 0.25rem 0.5rem;
+    border: none;
+    font-size: 0.9rem;
+}
+button.btn-link:hover { background: none; color: var(--brand); text-decoration: underline; }
+
+.button-row { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; margin-top: 1rem; }
+.button-row.right { justify-content: flex-end; }
+
+/* Forms */
+label { display: block; font-weight: 500; margin: 0.75rem 0 0.25rem; font-size: 0.9rem; }
+input[type="text"], select, textarea {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 0.95rem;
+    font-family: inherit;
+    background: var(--bg);
+    color: var(--text);
+}
+input[type="text"]:focus, select:focus, textarea:focus {
+    outline: 3px solid var(--brand-focus);
+    outline-offset: 1px;
+    border-color: var(--brand);
+}
+.form-help { font-size: 0.85rem; color: var(--text-muted); margin-top: 0.25rem; }
+.form-error { font-size: 0.9rem; color: var(--error); margin-top: 0.25rem; }
+
+/* Cards / list rows */
+.card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
+
+.namespace-list { list-style: none; }
+.namespace-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-bottom: 0.5rem;
+    background: var(--bg-surface);
+}
+.namespace-list .name { font-weight: 600; }
+.namespace-list .meta { font-size: 0.85rem; color: var(--text-muted); }
+.namespace-list .badges { display: flex; gap: 0.4rem; }
+
+.badge {
+    display: inline-block;
+    padding: 0.1rem 0.5rem;
+    font-size: 0.75rem;
+    border-radius: 999px;
+    background: var(--bg-code);
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.badge.admin { background: rgba(214, 48, 49, 0.12); color: var(--danger); }
+.badge.user  { background: rgba(2, 170, 162, 0.12); color: var(--brand); }
+
+/* JSON editor */
+.editor-wrap {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: var(--bg-code);
+}
+.editor-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.4rem 0.6rem;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+}
+.editor-toolbar .lhs { display: flex; gap: 0.4rem; }
+.editor-toolbar .status { color: var(--text-muted); font-family: ui-monospace, monospace; }
+.editor-toolbar .status.error { color: var(--error); }
+.editor-toolbar .status.ok    { color: var(--success); }
+
+textarea.editor {
+    width: 100%;
+    min-height: 360px;
+    padding: 0.6rem 0.8rem;
+    border: 0;
+    background: transparent;
+    color: var(--text);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 13px;
+    line-height: 1.55;
+    tab-size: 2;
+    resize: vertical;
+}
+textarea.editor:focus { outline: none; }
+
+/* Toast */
+#toast {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--text);
+    color: var(--bg);
+    padding: 0.6rem 1rem;
+    border-radius: var(--radius);
+    font-size: 0.9rem;
+    z-index: 100;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+#toast.error { background: var(--danger); color: #fff; }
+
+/* Empty / loading states */
+.empty, .loading {
+    padding: 2rem 1rem;
+    text-align: center;
+    color: var(--text-muted);
+    background: var(--bg-surface);
+    border: 1px dashed var(--border);
+    border-radius: var(--radius);
+}

--- a/scripts/e2e-config.sh
+++ b/scripts/e2e-config.sh
@@ -259,9 +259,63 @@ STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
   -H "Authorization: Bearer $ADMIN_TOK" "$CFG_BASE/api/v1/config/mqtt")
 check "GET after DELETE = 404" "404" "$STATUS"
 
-# ── 11. Cleanup ──────────────────────────────────────────────────────
+# ── 11. SPA logout actually revokes the refresh token ─────────────────
+# Regression for the auth.js logout fix. The SPA used to call
+# /api/v1/auth/logout without an Authorization header — silently 401'd.
+# This test does a fresh login (so we don't break the global ADMIN_TOK
+# used by Cleanup), revokes via the same call shape the SPA uses, and
+# asserts the refresh token is dead server-side.
 echo
-echo "=== 11. Cleanup ==="
+echo "=== 11. SPA logout revokes refresh token ==="
+LOGOUT_LOGIN=$(curl -s -X POST "$ID_BASE/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}")
+LOGOUT_ACCESS=$(json_field "$LOGOUT_LOGIN" access_token)
+LOGOUT_REFRESH=$(json_field "$LOGOUT_LOGIN" refresh_token)
+if [ -n "$LOGOUT_ACCESS" ] && [ -n "$LOGOUT_REFRESH" ]; then
+  check "fresh login returned access + refresh tokens" "yes" "yes"
+else
+  check "fresh login returned access + refresh tokens" "yes" "no"
+  echo "login response: $LOGOUT_LOGIN"
+  exit 1
+fi
+
+# Confirm refresh works before logout, and capture the rotated pair.
+# (Identity rotates on every refresh, so we can't pre-check then re-use
+# the original token — that would trip token-family-compromise. Instead
+# we pre-check via the rotation itself, then use the rotated pair to
+# exercise logout.)
+ROTATED=$(curl -s -X POST "$ID_BASE/api/v1/auth/refresh" \
+  -H 'Content-Type: application/json' \
+  -d "{\"refresh_token\":\"$LOGOUT_REFRESH\"}")
+LOGOUT_ACCESS=$(json_field "$ROTATED" access_token)
+LOGOUT_REFRESH=$(json_field "$ROTATED" refresh_token)
+if [ -n "$LOGOUT_ACCESS" ] && [ -n "$LOGOUT_REFRESH" ]; then
+  check "refresh works before logout" "yes" "yes"
+else
+  check "refresh works before logout" "yes" "no"
+  echo "refresh response: $ROTATED"
+  exit 1
+fi
+
+# Now logout the SPA way — Authorization: Bearer + refresh_token in body.
+LOGOUT_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$ID_BASE/api/v1/auth/logout" \
+  -H "Authorization: Bearer $LOGOUT_ACCESS" \
+  -H 'Content-Type: application/json' \
+  -d "{\"refresh_token\":\"$LOGOUT_REFRESH\"}")
+check "SPA logout call accepted" "204" "$LOGOUT_STATUS"
+
+# Refresh must now fail — the token is dead server-side. Identity returns
+# 401 invalid_refresh_token (or 401 token_family_compromised on replay
+# of an already-rotated token).
+POST_STATUS=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$ID_BASE/api/v1/auth/refresh" \
+  -H 'Content-Type: application/json' \
+  -d "{\"refresh_token\":\"$LOGOUT_REFRESH\"}")
+check "refresh fails after logout (token revoked)" "401" "$POST_STATUS"
+
+# ── 12. Cleanup ──────────────────────────────────────────────────────
+echo
+echo "=== 12. Cleanup ==="
 if [ -n "$USER_ID" ]; then
   STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
     -X DELETE "$ID_BASE/api/v1/users/$USER_ID" \


### PR DESCRIPTION
A small admin UI for the config service mounted at / when OAUTH_CLIENT_ID and IDENTITY_PUBLIC_URL are set. The browser authenticates against identity via Authorization Code + PKCE (mirrors examples/spa-demo); tokens land in localStorage; the SPA calls the existing /api/v1/config/* endpoints with a Bearer header. There is no new server-side session, no cookie crypto, no CSRF middleware — the config service stays purely API-driven.

  internal/ui-config/                Embedded SPA bundle.
    static/index.html                 Shell.
    static/auth.js                    PKCE flow, refresh, logout, authedFetch.
    static/api.js                     Thin wrapper over /api/v1/config.
    static/editor.js                  Pimped <textarea>: monospace, Tab=2sp,
                                      Format button, live JSON parser with
                                      line/col error reporting.
    static/app.js                     Hash router + list/new/edit/acl/delete views.
    static/style.css                  Mirrors identity's brand variables and
                                      dark-mode handling.

  internal/handler/config/router.go  mountSPA wires GET /, GET /static/*,
                                      and GET /spa-config.json. All three
                                      unauth (PKCE happens client-side).

  cmd/server/config.go               configSecurityHeaders is now path-aware:
                                      - / + /static/* + /spa-config.json get a
                                        permissive CSP (script-src 'self',
                                        connect-src + form-action include the
                                        identity URL for the OAuth flow).
                                      - /api/* keeps default-src 'none'.

  internal/config/configsvc.go       New env vars: IDENTITY_PUBLIC_URL (browser-
                                      facing identity URL; defaults to
                                      IDENTITY_ISSUER_URL), OAUTH_CLIENT_ID
                                      (public OAuth client_id; mounting the SPA
                                      requires both).

  docs/config-admin.md               New "Admin UI" section: register the
                                      OAuth client on identity, env vars,
                                      Cloudflared route example, threat-model
                                      notes (localStorage tradeoff, CSP,
                                      revocation lag).
  deploy/config-env.example          Documents OAUTH_CLIENT_ID +
                                      IDENTITY_PUBLIC_URL.

Verification:
  - go vet clean.
  - All unit + integration suites green.
  - All 5 existing e2e scripts pass (62 + 33 + 42 + 25 + 34 = 196).
  - Live smoke: started identity (8181) + config (8282) with the SPA enabled; confirmed / serves index.html with the relaxed CSP, /api/* stays under the strict CSP, /spa-config.json carries the right values, /static/* serves the bundle, and disabling OAUTH_CLIENT_ID returns 404 on the SPA paths.
  - Browser-side flow (OAuth round-trip, CRUD via fetch) requires actually opening a browser and was not exercised in this sandbox; the JS code follows examples/spa-demo's already-tested patterns closely.

Off by default — existing API-only deployments are unaffected.