### PR TITLE
Surface namespace ACL on GET via X-Read-Role / X-Write-Role headers

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -332,6 +332,7 @@ func configSecurityHeaders(next http.Handler, corsOrigins []string, identityURL 
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+				w.Header().Set("Access-Control-Expose-Headers", "X-Read-Role, X-Write-Role")
 				w.Header().Set("Access-Control-Max-Age", "86400")
 			}
 			if r.Method == http.MethodOptions {

--- a/internal/handler/config/router.go
+++ b/internal/handler/config/router.go
@@ -260,6 +260,8 @@ func getHandler(svc *service.ConfigService) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("X-Read-Role", got.ReadRole)
 		w.Header().Set("X-Write-Role", got.WriteRole)
+		w.Header().Set("Cache-Control", "private, no-store")
+		w.Header().Set("Vary", "Authorization")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(got.Document)
 	}

--- a/internal/handler/config/router.go
+++ b/internal/handler/config/router.go
@@ -255,8 +255,11 @@ func getHandler(svc *service.ConfigService) http.HandlerFunc {
 		}
 		// Return the raw stored document so callers can parse it with a
 		// plain JSON decoder. The document is validated as a JSON object
-		// on the write path.
+		// on the write path. ACL headers let clients avoid a second list
+		// call just to display role information.
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Read-Role", got.ReadRole)
+		w.Header().Set("X-Write-Role", got.WriteRole)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(got.Document)
 	}
@@ -355,6 +358,8 @@ func updateACLHandler(svc *service.ConfigService) http.HandlerFunc {
 			translateError(w, err)
 			return
 		}
+		w.Header().Set("X-Read-Role", b.ReadRole)
+		w.Header().Set("X-Write-Role", b.WriteRole)
 		writeJSON(w, http.StatusOK, map[string]string{
 			"name":       ns,
 			"read_role":  b.ReadRole,

--- a/internal/handler/config/router_test.go
+++ b/internal/handler/config/router_test.go
@@ -386,6 +386,47 @@ func TestPut_OversizedBody_Returns413(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
 }
 
+// --- ACL response headers ---
+
+func TestGet_ReturnsACLHeaders(t *testing.T) {
+	h := newHarness(t)
+	now := time.Now().UTC()
+	require.NoError(t, h.repo.Create(&domain.ConfigNamespace{
+		Name: "prefs", ReadRole: "user", WriteRole: "admin",
+		Document: []byte(`{"x":1}`), UpdatedAt: now, UpdatedBy: "u", CreatedAt: now,
+	}))
+	resp, _ := h.do("GET", "/api/v1/config/prefs", h.adminTok, nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "user", resp.Header.Get("X-Read-Role"))
+	assert.Equal(t, "admin", resp.Header.Get("X-Write-Role"))
+}
+
+func TestGet_ACLHeaders_MatchStoredACL(t *testing.T) {
+	h := newHarness(t)
+	now := time.Now().UTC()
+	require.NoError(t, h.repo.Create(&domain.ConfigNamespace{
+		Name: "sec", ReadRole: "admin", WriteRole: "admin",
+		Document: []byte(`{}`), UpdatedAt: now, UpdatedBy: "u", CreatedAt: now,
+	}))
+	resp, _ := h.do("GET", "/api/v1/config/sec", h.adminTok, nil)
+	assert.Equal(t, "admin", resp.Header.Get("X-Read-Role"))
+	assert.Equal(t, "admin", resp.Header.Get("X-Write-Role"))
+}
+
+func TestPatchACL_ReturnsACLHeaders(t *testing.T) {
+	h := newHarness(t)
+	now := time.Now().UTC()
+	require.NoError(t, h.repo.Create(&domain.ConfigNamespace{
+		Name: "n", ReadRole: "admin", WriteRole: "admin",
+		Document: []byte(`{}`), UpdatedAt: now, UpdatedBy: "u", CreatedAt: now,
+	}))
+	resp, _ := h.do("PATCH", "/api/v1/config/namespaces/n", h.adminTok,
+		map[string]string{"read_role": "user", "write_role": "admin"})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "user", resp.Header.Get("X-Read-Role"))
+	assert.Equal(t, "admin", resp.Header.Get("X-Write-Role"))
+}
+
 // --- PATCH ACL ---
 
 func TestPatchACL_AdminOnly(t *testing.T) {

--- a/internal/handler/config/router_test.go
+++ b/internal/handler/config/router_test.go
@@ -427,6 +427,50 @@ func TestPatchACL_ReturnsACLHeaders(t *testing.T) {
 	assert.Equal(t, "admin", resp.Header.Get("X-Write-Role"))
 }
 
+func TestPatchACL_GetHeadersMatchPatchHeaders(t *testing.T) {
+	// Regression: PATCH headers must reflect what's actually stored, not just
+	// echo the request. A subsequent GET must agree with the PATCH response.
+	h := newHarness(t)
+	now := time.Now().UTC()
+	require.NoError(t, h.repo.Create(&domain.ConfigNamespace{
+		Name: "n", ReadRole: "admin", WriteRole: "admin",
+		Document: []byte(`{}`), UpdatedAt: now, UpdatedBy: "u", CreatedAt: now,
+	}))
+	patchResp, _ := h.do("PATCH", "/api/v1/config/namespaces/n", h.adminTok,
+		map[string]string{"read_role": "user", "write_role": "admin"})
+	require.Equal(t, http.StatusOK, patchResp.StatusCode)
+
+	getResp, _ := h.do("GET", "/api/v1/config/n", h.adminTok, nil)
+	require.Equal(t, http.StatusOK, getResp.StatusCode)
+
+	assert.Equal(t, patchResp.Header.Get("X-Read-Role"), getResp.Header.Get("X-Read-Role"))
+	assert.Equal(t, patchResp.Header.Get("X-Write-Role"), getResp.Header.Get("X-Write-Role"))
+}
+
+func TestGet_NoACLHeadersOn404_ReadDenied(t *testing.T) {
+	// A user that lacks read_role sees 404. The ACL headers must be absent so
+	// header presence cannot be used as an existence oracle.
+	h := newHarness(t)
+	now := time.Now().UTC()
+	require.NoError(t, h.repo.Create(&domain.ConfigNamespace{
+		Name: "secret", ReadRole: "admin", WriteRole: "admin",
+		Document: []byte(`{}`), UpdatedAt: now, UpdatedBy: "u", CreatedAt: now,
+	}))
+	resp, _ := h.do("GET", "/api/v1/config/secret", h.userTok, nil)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("X-Read-Role"))
+	assert.Empty(t, resp.Header.Get("X-Write-Role"))
+}
+
+func TestGet_NoACLHeadersOn404_Missing(t *testing.T) {
+	// A truly missing namespace must also return no ACL headers.
+	h := newHarness(t)
+	resp, _ := h.do("GET", "/api/v1/config/nonexistent", h.adminTok, nil)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("X-Read-Role"))
+	assert.Empty(t, resp.Header.Get("X-Write-Role"))
+}
+
 // --- PATCH ACL ---
 
 func TestPatchACL_AdminOnly(t *testing.T) {

--- a/internal/spec/config-openapi.yaml
+++ b/internal/spec/config-openapi.yaml
@@ -215,6 +215,13 @@ paths:
       responses:
         "200":
           description: Stored JSON document verbatim
+          headers:
+            X-Read-Role:
+              description: Role required to read this namespace (`admin` or `user`)
+              schema: { type: string, enum: [admin, user] }
+            X-Write-Role:
+              description: Role required to write this namespace (`admin` or `user`)
+              schema: { type: string, enum: [admin, user] }
           content:
             application/json:
               schema: { $ref: '#/components/schemas/NamespaceDocument' }
@@ -290,6 +297,13 @@ paths:
       responses:
         "200":
           description: Updated
+          headers:
+            X-Read-Role:
+              description: New read role after the update (`admin` or `user`)
+              schema: { type: string, enum: [admin, user] }
+            X-Write-Role:
+              description: New write role after the update (`admin` or `user`)
+              schema: { type: string, enum: [admin, user] }
           content:
             application/json:
               schema: { $ref: '#/components/schemas/NamespaceSummary' }

--- a/internal/ui-config/static/api.js
+++ b/internal/ui-config/static/api.js
@@ -24,7 +24,15 @@ window.ConfigAPI = (function () {
 
   return {
     list:     async ()             => check(await Auth.authedFetch(api(''))),
-    get:      async (ns)           => check(await Auth.authedFetch(api('/' + encodeURIComponent(ns)))),
+    get:      async (ns)           => {
+      const resp = await Auth.authedFetch(api('/' + encodeURIComponent(ns)));
+      const document = await check(resp);
+      return {
+        document,
+        readRole:  resp.headers.get('X-Read-Role'),
+        writeRole: resp.headers.get('X-Write-Role'),
+      };
+    },
     put:      async (ns, doc) => check(await Auth.authedFetch(api('/' + encodeURIComponent(ns)), {
       method:  'PUT',
       headers: { 'Content-Type': 'application/json' },

--- a/internal/ui-config/static/app.js
+++ b/internal/ui-config/static/app.js
@@ -177,9 +177,9 @@
     const status = el('div', { class: 'loading', text: 'Loading…' });
     root.appendChild(status);
 
-    let doc;
+    let doc, readRole, writeRole;
     try {
-      doc = await ConfigAPI.get(name);
+      ({ document: doc, readRole, writeRole } = await ConfigAPI.get(name));
     } catch (e) {
       root.removeChild(status);
       if (e.status === 404) {
@@ -190,13 +190,6 @@
       return root;
     }
     root.removeChild(status);
-
-    // List endpoint also returns ACL; fetch the full list once to find this row.
-    let aclRow = null;
-    try {
-      const list = await ConfigAPI.list();
-      aclRow = (list || []).find(r => r.name === name) || null;
-    } catch (_) { /* non-fatal */ }
 
     // ─ Document edit ─
     root.appendChild(el('h2', { text: 'Document' }));
@@ -227,7 +220,7 @@
     revertBtn.addEventListener('click', async () => {
       try {
         const fresh = await ConfigAPI.get(name);
-        editor.setValue(JSON.stringify(fresh, null, 2) + '\n');
+        editor.setValue(JSON.stringify(fresh.document, null, 2) + '\n');
         toast('Reverted to stored version');
       } catch (err) {
         toast('Revert failed: ' + err.message, 'error');
@@ -238,8 +231,8 @@
 
     // ─ ACL ─
     root.appendChild(el('h2', { text: 'Access control' }));
-    const aclReadSel  = roleSelect('read_role',  aclRow ? aclRow.read_role  : 'admin');
-    const aclWriteSel = roleSelect('write_role', aclRow ? aclRow.write_role : 'admin');
+    const aclReadSel  = roleSelect('read_role',  readRole  || 'admin');
+    const aclWriteSel = roleSelect('write_role', writeRole || 'admin');
     const aclErr = el('div', { class: 'form-error' });
     const aclBtn = el('button', { type: 'button', text: 'Update ACL' });
     aclBtn.addEventListener('click', async () => {

--- a/scripts/e2e-config.sh
+++ b/scripts/e2e-config.sh
@@ -155,6 +155,15 @@ check_contains "admin reads 'houses'" "Rivendell" "$BODY"
 BODY=$(curl -s -H "Authorization: Bearer $ADMIN_TOK" "$CFG_BASE/api/v1/config/mqtt")
 check_contains "admin reads 'mqtt'" "homelab" "$BODY"
 
+# ACL headers on admin GET.
+HEADERS=$(curl -sI -H "Authorization: Bearer $ADMIN_TOK" "$CFG_BASE/api/v1/config/houses")
+check_contains "GET 'houses' includes X-Read-Role: admin"  "X-Read-Role: admin"  "$HEADERS"
+check_contains "GET 'houses' includes X-Write-Role: admin" "X-Write-Role: admin" "$HEADERS"
+
+HEADERS=$(curl -sI -H "Authorization: Bearer $ADMIN_TOK" "$CFG_BASE/api/v1/config/mqtt")
+check_contains "GET 'mqtt' includes X-Read-Role: user"   "X-Read-Role: user"  "$HEADERS"
+check_contains "GET 'mqtt' includes X-Write-Role: admin" "X-Write-Role: admin" "$HEADERS"
+
 # User reads mqtt (read_role=user) but is 404 on houses (read_role=admin).
 STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
   -H "Authorization: Bearer $USER_TOK" "$CFG_BASE/api/v1/config/mqtt")


### PR DESCRIPTION
Fixes #6.

## Summary

- `GET /api/v1/config/{ns}` now returns `X-Read-Role` and `X-Write-Role` headers populated from the namespace ACL (already fetched server-side for the role-check, so no extra query)
- `PATCH /api/v1/config/namespaces/{ns}` mirrors the same headers for symmetry
- OpenAPI spec documents both headers on both endpoints
- SPA `api.js` `get()` returns `{document, readRole, writeRole}` by reading the headers
- SPA `app.js` `viewEdit()` destructures the new shape, dropping the redundant `list()` call (and the ACL race window that came with it)
- `router_test.go`: 3 new tests asserting correct header values on GET and PATCH
- `e2e-config.sh`: 4 new assertions checking `X-Read-Role` / `X-Write-Role` on GET for both namespaces

## Test plan

- [x] `make test-all` — all packages green (unit + integration, race detector)
- [x] New router tests pass: `TestGet_ReturnsACLHeaders`, `TestGet_ACLHeaders_MatchStoredACL`, `TestPatchACL_ReturnsACLHeaders`
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)