### PR TITLE
Apply strict auth rate limiter to POST /oauth/device password approval

### DIFF
--- a/cmd/server/identity.go
+++ b/cmd/server/identity.go
@@ -357,9 +357,9 @@ func runIdentityServer() error {
 	// All auth endpoints that accept credentials must use the strict rate limiter:
 	//   POST /api/v1/auth/login, POST /oauth/token, POST /oauth/authorize, POST /admin/login
 	oauthRouter := oauthhandler.NewRouter(oauthSvc, cfg.TrustProxy, issuer, authSvc, webauthnSvc, deviceSvc, secrets.Session, cfg.SiteName)
-	mux.Handle("POST /oauth/token", wrapAuth(oauthRouter))
-	mux.Handle("POST /oauth/authorize", wrapAuth(oauthRouter))
-	mux.Handle("POST /oauth/introspect", wrapAuth(oauthRouter))
+	for _, route := range strictOAuthRoutes() {
+		mux.Handle(route, wrapAuth(oauthRouter))
+	}
 	mux.Handle("/oauth/", oauthRouter)
 	adminRouter := admin.NewRouter(admin.Config{
 		SessionSecret: secrets.Session,
@@ -438,6 +438,24 @@ func runIdentityServer() error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 	return srv.Shutdown(shutdownCtx)
+}
+
+// strictOAuthRoutes lists the /oauth POST routes that accept credentials and so
+// must be wrapped in the strict auth rate limiter (registered before the broad
+// "/oauth/" catch-all). Each route checks a password or client secret, making it
+// a brute-force surface. Returned as data so the rate-limit wiring test can
+// assert against the exact set the server registers.
+func strictOAuthRoutes() []string {
+	return []string{
+		"POST /oauth/token",
+		"POST /oauth/authorize",
+		"POST /oauth/introspect",
+		// deviceVerifyPost validates username+password (h.authSvc.AuthorizeUser),
+		// so it is a brute-force surface and needs the strict limiter — unlike
+		// GET /oauth/device (the page) and POST /oauth/device/passkey (token, no
+		// password), which fall through to the general "/oauth/" limiter.
+		"POST /oauth/device",
+	}
 }
 
 // securityHeaders wraps a handler with standard security response headers.

--- a/cmd/server/ratelimit_wiring_test.go
+++ b/cmd/server/ratelimit_wiring_test.go
@@ -69,6 +69,53 @@ func TestAdminReauthEndpoints_StrictRateLimiting(t *testing.T) {
 	}
 }
 
+// TestDeviceVerifyEndpoint_StrictRateLimiting mirrors the oauth device-flow
+// wiring in run(): POST /oauth/device authenticates with username+password
+// (deviceVerifyPost) and so must sit behind the strict auth limiter, while
+// POST /oauth/device/passkey carries an already-issued access token (no
+// password) and must NOT be throttled by the strict limiter. The mux uses
+// http.ServeMux precedence exactly like run() — a specific strict-limited
+// pattern wins over the broad "/oauth/" catch-all.
+func TestDeviceVerifyEndpoint_StrictRateLimiting(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Every POST /oauth route registered with wrapAuth gets the strict limiter
+	// here, plus the broad "/oauth/" catch-all carrying only the general limiter.
+	// This lets the test assert which device routes the strict limiter covers.
+	strictRL := ratelimit.NewLimiter(5.0/60.0, 1, "") // burst 1
+	mux := http.NewServeMux()
+	for _, route := range strictOAuthRoutes() {
+		mux.Handle(route, strictRL.Middleware(inner))
+	}
+	mux.Handle("/oauth/", inner) // catch-all: not strict-limited
+
+	// POST /oauth/device (password) must be strictly limited: first passes,
+	// second from the same IP is rejected.
+	req1 := httptest.NewRequest(http.MethodPost, "/oauth/device", nil)
+	rr1 := httptest.NewRecorder()
+	mux.ServeHTTP(rr1, req1)
+	require.Equal(t, http.StatusOK, rr1.Code, "first POST /oauth/device must pass the strict limiter")
+
+	req2 := httptest.NewRequest(http.MethodPost, "/oauth/device", nil)
+	rr2 := httptest.NewRecorder()
+	mux.ServeHTTP(rr2, req2)
+	assert.Equal(t, http.StatusTooManyRequests, rr2.Code,
+		"second POST /oauth/device must be strict-rate-limited (password brute-force protection)")
+
+	// POST /oauth/device/passkey (token, no password) must NOT be caught by the
+	// strict limiter — it falls through to the catch-all, so repeated requests
+	// from the same IP all pass the strict bucket.
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/oauth/device/passkey", nil)
+		rr := httptest.NewRecorder()
+		mux.ServeHTTP(rr, req)
+		require.Equalf(t, http.StatusOK, rr.Code,
+			"POST /oauth/device/passkey request %d must not hit the strict limiter", i)
+	}
+}
+
 // TestRateLimitExempt verifies which paths bypass the general rate limiter.
 // Static assets and the health check must be exempt; credential and API paths
 // must not be.


### PR DESCRIPTION
Fixes #9

## Problem
`POST /oauth/device` (`deviceVerifyPost`) performs a full username+password authentication via `authSvc.AuthorizeUser(...)`, but it fell through to the `/oauth/` catch-all route and only received the **general** rate limiter (~120/min) instead of the strict auth limiter (~5/min) that every other password-checking endpoint uses. This gave attackers ~24× the brute-force budget against any account, reachable by anyone who can obtain a `user_code` from the public device-authorization endpoint.

## Fix
- Added `POST /oauth/device` to the strict-limited route set so it is wrapped in `wrapAuth` before the catch-all.
- `GET /oauth/device` (the page) and `POST /oauth/device/passkey` (validates an already-signed token, no password) are correctly left on the general limiter.
- Moved the strict-route list out of the test and into production code (`cmd/server/identity.go`) so the server and the wiring test register from a single source of truth — the previous test was self-fulfilling (it built its mux from its own hardcoded list and never validated production wiring).

## Test
Extended `cmd/server/ratelimit_wiring_test.go` (`TestDeviceVerifyEndpoint_StrictRateLimiting`) to assert against the **real** production route set: `POST /oauth/device` returns 429 after the strict burst is exhausted, while `POST /oauth/device/passkey` is never strict-throttled. Confirmed failing before the fix, passing after.

`go build ./...`, `go test ./cmd/...`, `go test ./internal/handler/oauth/...`, `go vet ./cmd/...` all clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XP9JVCj1EQErwKZj9nedHM)_