### PR TITLE
Re-validate IsActive/Role against the DB in API auth middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,8 @@ See `docs/passkeys.md` for full API reference and integration guide.
 
 Every refresh rotates the token: old token is revoked, new pair issued. If a **previously-used** refresh token is ever presented again, the server assumes the token was stolen. It revokes the **entire token family** and returns `token_family_compromised`. The client must clear all tokens and show the login screen.
 
+Disabling or demoting an account takes effect **immediately** on the API, not just at access-token expiry: the `RequireAuth` middleware re-reads the user's live `IsActive`/`Role` from the database on every authenticated request (`RequireAuthWithStatus` in `internal/auth/middleware.go`, wired in `internal/handler/api/router.go`). A disabled user is rejected with `account_disabled`, and a demoted admin loses admin access on the next request. (Sibling resource servers that verify tokens via the published JWKS have no user database and keep the stateless behavior — their access tokens remain valid until expiry.)
+
 ## Role model
 
 - `admin` — full access to all endpoints including user management and admin UI

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -43,6 +43,23 @@ func ServiceClaimsFromContext(ctx context.Context) *domain.ServiceTokenClaims {
 	return c
 }
 
+// UserStatus is the live account state for a user, read from the database at
+// request time. It lets middleware reject access tokens that are still
+// cryptographically valid and unexpired but were minted before the account was
+// disabled or its role changed.
+type UserStatus struct {
+	IsActive bool
+	Role     domain.Role
+}
+
+// UserStatusProvider returns the current account state for a user ID. The
+// identity server implements this against its user store; sibling services
+// (which only hold the public JWKS and have no user database) pass nil to
+// RequireAuth and keep the stateless behavior.
+type UserStatusProvider interface {
+	UserStatus(ctx context.Context, userID string) (UserStatus, error)
+}
+
 // RequireAuth is an HTTP middleware that validates the Bearer token in the
 // Authorization header and injects the claims into the request context.
 // Returns 401 if the token is missing or invalid, 403 if the user is inactive.
@@ -50,7 +67,27 @@ func ServiceClaimsFromContext(ctx context.Context) *domain.ServiceTokenClaims {
 // The first parameter accepts any TokenParser. Identity passes its
 // in-process *TokenIssuer; sibling services pass a *JWKSVerifier that
 // validates tokens against identity's published JWKS.
+//
+// This form trusts the IsActive/Role claims embedded in the token. The
+// identity server should use RequireAuthWithStatus so that disabling or
+// demoting an account takes effect immediately rather than at token expiry.
 func RequireAuth(parser TokenParser, next http.Handler) http.Handler {
+	return RequireAuthWithStatus(parser, nil, next)
+}
+
+// RequireAuthWithStatus is RequireAuth plus an optional live-status check.
+//
+// When provider is non-nil, after the token verifies the middleware loads the
+// user's current IsActive/Role from the provider (a fresh DB read) and uses
+// those values instead of the token's copies. This closes the window where a
+// disabled or demoted user keeps API access until their unexpired access token
+// would have expired. The freshly-loaded role is written into the context
+// claims so the downstream RequireAdmin sees the live role, not the stale one.
+//
+// When provider is nil the behavior is identical to RequireAuth: claims are
+// taken verbatim from the token. Service (client_credentials) tokens are never
+// subject to the user-status check — they have no associated user.
+func RequireAuthWithStatus(parser TokenParser, provider UserStatusProvider, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
@@ -90,6 +127,19 @@ func RequireAuth(parser TokenParser, next http.Handler) http.Handler {
 			w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
 			writeError(w, http.StatusUnauthorized, "unauthorized", "invalid or expired token")
 			return
+		}
+
+		// When a status provider is configured, re-read the live account state
+		// so disable/demote take effect immediately instead of at token expiry.
+		// A lookup failure (e.g. user deleted) is treated as access denied.
+		if provider != nil {
+			status, statusErr := provider.UserStatus(r.Context(), claims.UserID)
+			if statusErr != nil {
+				writeError(w, http.StatusForbidden, "account_disabled", "account is no longer valid")
+				return
+			}
+			claims.IsActive = status.IsActive
+			claims.Role = status.Role
 		}
 
 		if !claims.IsActive {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,6 +1,7 @@
 package auth_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -149,4 +150,113 @@ func TestRequireAdmin_NonAdminUser(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+// stubStatusProvider is a UserStatusProvider backed by an in-memory map,
+// letting tests simulate the live DB state diverging from the (still-valid)
+// access token claims.
+type stubStatusProvider struct {
+	active map[string]bool
+	roles  map[string]domain.Role
+	err    error
+}
+
+func (s stubStatusProvider) UserStatus(_ context.Context, userID string) (auth.UserStatus, error) {
+	if s.err != nil {
+		return auth.UserStatus{}, s.err
+	}
+	role := s.roles[userID]
+	if role == "" {
+		role = domain.RoleUser
+	}
+	return auth.UserStatus{IsActive: s.active[userID], Role: role}, nil
+}
+
+// A user disabled in the DB must be rejected even while holding a still-valid
+// access token minted with act:true. This is the core of issue #11.
+func TestRequireAuthWithStatus_DisabledUserRejected(t *testing.T) {
+	issuer := newTestIssuer(t)
+
+	// Token was minted while the user was active and is not expired.
+	token, err := issuer.Mint(domain.TokenClaims{UserID: "u1", Username: "alice", Role: domain.RoleUser, IsActive: true})
+	require.NoError(t, err)
+
+	// DB now says the user is disabled.
+	provider := stubStatusProvider{
+		active: map[string]bool{"u1": false},
+		roles:  map[string]domain.Role{"u1": domain.RoleUser},
+	}
+
+	handler := auth.RequireAuthWithStatus(issuer, provider, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+// An admin demoted to user in the DB must be rejected by RequireAdmin even
+// while holding a still-valid access token minted with rol:admin.
+func TestRequireAdmin_DemotedAdminRejected(t *testing.T) {
+	issuer := newTestIssuer(t)
+
+	// Token was minted while the user was an admin and is not expired.
+	token, err := issuer.Mint(domain.TokenClaims{UserID: "u1", Username: "admin", Role: domain.RoleAdmin, IsActive: true})
+	require.NoError(t, err)
+
+	// DB now says the user is a plain user (active, but demoted).
+	provider := stubStatusProvider{
+		active: map[string]bool{"u1": true},
+		roles:  map[string]domain.Role{"u1": domain.RoleUser},
+	}
+
+	handler := auth.RequireAuthWithStatus(issuer, provider, auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+// A still-active, still-admin user passes through with the fresh status, and
+// the claims injected into context reflect the live DB values.
+func TestRequireAuthWithStatus_FreshClaimsInjected(t *testing.T) {
+	issuer := newTestIssuer(t)
+
+	// Token minted as a plain user...
+	token, err := issuer.Mint(domain.TokenClaims{UserID: "u1", Username: "alice", Role: domain.RoleUser, IsActive: true})
+	require.NoError(t, err)
+
+	// ...but DB has since promoted them to admin. RequireAdmin must honor the
+	// fresh role and allow the request.
+	provider := stubStatusProvider{
+		active: map[string]bool{"u1": true},
+		roles:  map[string]domain.Role{"u1": domain.RoleAdmin},
+	}
+
+	var captured *domain.TokenClaims
+	handler := auth.RequireAuthWithStatus(issuer, provider, auth.RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = auth.ClaimsFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	require.NotNil(t, captured)
+	assert.Equal(t, domain.RoleAdmin, captured.Role)
 }

--- a/internal/handler/api/router.go
+++ b/internal/handler/api/router.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -69,13 +70,24 @@ func NewRouter(issuer *auth.TokenIssuer, authSvc service.AuthServicer, userSvc s
 	ah := &authHandler{svc: authSvc, trustProxy: trustProxy}
 	uh := &userHandler{svc: userSvc, trustProxy: trustProxy}
 
+	// statusProvider re-reads the user's live IsActive/Role on each authenticated
+	// request so that disabling or demoting an account takes effect immediately
+	// instead of lingering until the (up to 15-minute) access token expires.
+	// It is nil-safe: if userSvc is nil (handler-isolation tests) the middleware
+	// falls back to trusting the token claims.
+	var statusProvider auth.UserStatusProvider
+	if userSvc != nil {
+		statusProvider = userStatusProvider{svc: userSvc}
+	}
+
 	// requireUserAuth wraps a handler with RequireAuth + RequireAudience to ensure:
 	// 1. The request has a valid bearer token.
-	// 2. Service tokens (client_credentials) are rejected unless they were issued for this
+	// 2. The user is still active and their role is current (live DB check).
+	// 3. Service tokens (client_credentials) are rejected unless they were issued for this
 	//    specific identity server (audience must match the issuer string). This prevents
 	//    cross-service token replay where a token for service-A is used against this API.
 	requireUserAuth := func(next http.Handler) http.Handler {
-		return auth.RequireAuth(issuer, auth.RequireAudience(issuer.Issuer())(next))
+		return auth.RequireAuthWithStatus(issuer, statusProvider, auth.RequireAudience(issuer.Issuer())(next))
 	}
 
 	// handlers maps "METHOD /path" to the handler for that route. Routes whose
@@ -129,4 +141,19 @@ func NewRouter(issuer *auth.TokenIssuer, authSvc service.AuthServicer, userSvc s
 	}
 
 	return mux
+}
+
+// userStatusProvider adapts the UserServicer into auth.UserStatusProvider,
+// translating a not-found/error lookup into a non-nil error so the middleware
+// denies access (e.g. for a since-deleted user).
+type userStatusProvider struct {
+	svc service.UserServicer
+}
+
+func (p userStatusProvider) UserStatus(_ context.Context, userID string) (auth.UserStatus, error) {
+	user, err := p.svc.GetByID(userID)
+	if err != nil {
+		return auth.UserStatus{}, err
+	}
+	return auth.UserStatus{IsActive: user.IsActive, Role: user.Role}, nil
 }

--- a/internal/handler/api/users_test.go
+++ b/internal/handler/api/users_test.go
@@ -83,6 +83,14 @@ func sampleUser(id string) *domain.User {
 	}
 }
 
+// expectAdminStatusLookup registers the live-status DB read that RequireAuth now
+// performs on every authenticated request, for the admin actor "admin-1". The
+// returned user is an active admin so the request proceeds.
+func expectAdminStatusLookup(userSvc *mocks.MockUserServicer) {
+	admin := &domain.User{ID: "admin-1", Username: "admin", Role: domain.RoleAdmin, IsActive: true}
+	userSvc.EXPECT().GetByID("admin-1").Return(admin, nil)
+}
+
 // --- GET /api/v1/users ---
 
 func TestListUsers_AdminSuccess(t *testing.T) {
@@ -90,6 +98,7 @@ func TestListUsers_AdminSuccess(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	users := []*domain.User{sampleUser("1"), sampleUser("2")}
 	userSvc.EXPECT().List().Return(users, nil)
 
@@ -124,6 +133,7 @@ func TestCreateUser_AdminSuccess(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	created := sampleUser("new-1")
 	userSvc.EXPECT().Create("newuser", "New User", "strongpassword1", domain.RoleUser, gomock.Any()).Return(created, nil)
 
@@ -143,6 +153,7 @@ func TestCreateUser_DuplicateUsername(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	userSvc.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, domain.ErrConflict)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")
@@ -161,6 +172,7 @@ func TestCreateUser_UserLimitReached(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	userSvc.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, domain.ErrUserLimitReached)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")
@@ -181,6 +193,7 @@ func TestGetUser_AdminCanGetAnyUser(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	userSvc.EXPECT().GetByID("u-999").Return(sampleUser("u-999"), nil)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")
@@ -193,7 +206,9 @@ func TestGetUser_UserCanGetSelf(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
-	userSvc.EXPECT().GetByID("user-123").Return(sampleUser("user-123"), nil)
+	// Called twice: once by the middleware live-status check (actor) and once by
+	// the handler (target) — both resolve to the same self ID here.
+	userSvc.EXPECT().GetByID("user-123").Return(sampleUser("user-123"), nil).Times(2)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")
 	rr := authGet(t, h, "/api/v1/users/user-123", userToken(t, issuer, "user-123"))
@@ -213,6 +228,7 @@ func TestGetUser_NotFound(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	userSvc.EXPECT().GetByID("ghost").Return(nil, domain.ErrNotFound)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")
@@ -227,6 +243,7 @@ func TestUpdateUser_AdminSuccess(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	updated := sampleUser("u-1")
 	updated.DisplayName = "Updated Name"
 	userSvc.EXPECT().Update("u-1", gomock.Any(), gomock.Any()).Return(updated, nil)
@@ -246,6 +263,7 @@ func TestDeleteUser_AdminSuccess(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	userSvc.EXPECT().Delete("u-del", gomock.Any()).Return(nil)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")
@@ -262,6 +280,7 @@ func TestDeleteUser_LastAdmin(t *testing.T) {
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	issuer := newTestIssuer(t)
 
+	expectAdminStatusLookup(userSvc)
 	userSvc.EXPECT().Delete("admin-1", gomock.Any()).Return(service.ErrCannotDeleteLastAdmin)
 
 	h := api.NewRouter(issuer, nil, userSvc, nil, "")


### PR DESCRIPTION
Fixes #11

## Problem
`RequireAuth`/`RequireAdmin` read `IsActive` and `Role` verbatim from the signed JWT access-token claims, never re-reading the DB. Disabling an account or demoting an admin revokes refresh tokens immediately, but an already-minted access token (`act:true` / `rol:admin`, ~15 min TTL) was still admitted — so a disabled user kept API access and a demoted admin kept **admin** access for the remainder of the token TTL. (The server-rendered admin UI was unaffected; it re-reads the user each request.)

## Fix — Option A (fresh DB re-read), implemented additively
Re-reading the user directly fixes both the disable and demote cases with no schema/migration and no dependence on `iat`. Because `RequireAuth(parser, next)` is a documented shared shape used by sibling resource servers with a `JWKSVerifier` and no user database, the dependency is **optional** to preserve backward compatibility:

- Added `auth.UserStatus` + `auth.UserStatusProvider` and `RequireAuthWithStatus(parser, provider, next)`. When a provider is supplied, after token verification it loads live `IsActive`/`Role` and overwrites the context claims; a lookup error denies access (also covers deleted users). `RequireAdmin` reads role from context and so automatically sees the fresh role.
- `RequireAuth(parser, next)` delegates with a `nil` provider → identical stateless behavior for sibling services and existing tests.
- Wired a `userStatusProvider` (backed by `UserServicer.GetByID`) into the API router's auth chain; nil-safe.
- Updated `CLAUDE.md` to describe the immediate-revocation semantics accurately.

## Tests
- `TestRequireAuthWithStatus_DisabledUserRejected` — disabled user with a valid `act:true` token → 403.
- `TestRequireAdmin_DemotedAdminRejected` — admin token but DB role=user → 403.
- `TestRequireAuthWithStatus_FreshClaimsInjected` — token role=user but DB role=admin → allowed, context reflects fresh role.
- Updated existing API handler tests to expect the per-request status lookup.

Confirmed failing before, passing after. `go build ./...`, `common/` build, and `go test -race -count=1 ./...` all pass.

## Trade-off
Adds one indexed `GetByID` per authenticated API request (cheap SQLite PK read). Optional brief caching was intentionally left out to keep revocation strictly immediate; it can be revisited if it ever shows up in profiling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XP9JVCj1EQErwKZj9nedHM)_