### PR TITLE
Validate the passkey-prompt `next` redirect (open redirect / latent XSS)

### DIFF
--- a/internal/handler/admin/admin_test.go
+++ b/internal/handler/admin/admin_test.go
@@ -1254,10 +1254,9 @@ func TestOAuthClientCreate_ValidClientID(t *testing.T) {
 
 // --- Passkey prompt ---
 
-// TestPasskeyPrompt_SkipURL_NotSanitized verifies that the SkipURL passed to
-// the passkey prompt page is rendered verbatim and not replaced with
-// #ZgotmplZ by html/template's URL sanitizer.
-func TestPasskeyPrompt_SkipURL_NotSanitized(t *testing.T) {
+// TestPasskeyPrompt_SafeRelativeNext verifies that a legitimate server-relative
+// next path is preserved and rendered as the "Not now" href.
+func TestPasskeyPrompt_SafeRelativeNext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	userSvc := mocks.NewMockUserServicer(ctrl)
 	handler := newRouter(t, userSvc)
@@ -1270,9 +1269,42 @@ func TestPasskeyPrompt_SkipURL_NotSanitized(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
-	body := rr.Body.String()
-	assert.Contains(t, body, next, "SkipURL must render the next URL intact")
-	assert.NotContains(t, body, "#ZgotmplZ", "html/template must not sanitize the SkipURL")
+	assert.Contains(t, rr.Body.String(), `href="/admin/some-page"`, "safe relative next must render intact")
+}
+
+// TestPasskeyPrompt_UnsafeNextFallsBack verifies that attacker-controllable next
+// values (absolute URLs, protocol-relative URLs, custom schemes, javascript:)
+// are rejected and fall back to the safe /admin/ default. No open redirect and
+// no unsanitized scheme reaches the href.
+func TestPasskeyPrompt_UnsafeNextFallsBack(t *testing.T) {
+	cases := []string{
+		"https://evil.example/login",      // absolute open redirect
+		"//evil.example",                  // protocol-relative
+		"javascript:alert(1)",             // latent XSS
+		"com.foo.bar://callback",          // custom scheme
+		"http://evil.example",             // absolute http
+		" /admin/ok",                      // leading whitespace then path
+	}
+	for _, next := range cases {
+		t.Run(next, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			userSvc := mocks.NewMockUserServicer(ctrl)
+			handler := newRouter(t, userSvc)
+			session := loginSession(t, handler)
+
+			req := httptest.NewRequest(http.MethodGet, "/admin/passkeys/prompt?next="+url.QueryEscape(next), nil)
+			req.AddCookie(session)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, http.StatusOK, rr.Code)
+			body := rr.Body.String()
+			assert.Contains(t, body, `href="/admin/"`, "unsafe next must fall back to /admin/")
+			assert.NotContains(t, body, "evil.example", "unsafe next must not appear in the response")
+			assert.NotContains(t, body, "javascript:", "javascript: scheme must not reach the href")
+			assert.NotContains(t, body, "com.foo.bar:", "custom scheme must not reach the href")
+		})
+	}
 }
 
 // TestPasskeyPrompt_DefaultSkipURL verifies that when no next parameter is

--- a/internal/handler/admin/handler.go
+++ b/internal/handler/admin/handler.go
@@ -12,6 +12,7 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -332,13 +333,39 @@ func (h *adminHandler) shouldPromptPasskey(userID string) bool {
 
 func (h *adminHandler) passkeyPrompt(w http.ResponseWriter, r *http.Request) {
 	next := r.URL.Query().Get("next")
-	if next == "" {
+	if !isSafeRelativePath(next) {
+		// next is attacker-controllable (the endpoint is reachable directly);
+		// reject anything that isn't a server-relative path to avoid an open
+		// redirect / latent XSS via the "Not now" link. Render as a plain
+		// string so html/template applies its URL filter as defence in depth.
 		next = "/admin/"
 	}
 	h.render(w, r, "passkey_prompt.html", map[string]any{
 		"HideNav": true,
-		"SkipURL": template.URL(next), //nolint:gosec // URL comes from the post-login redirect, which is /admin/ or set by server logic
+		"SkipURL": next,
 	})
+}
+
+// isSafeRelativePath reports whether p is a safe same-origin destination: a
+// non-empty server-relative path beginning with a single "/". It rejects
+// protocol-relative URLs ("//host"), absolute URLs, and any value carrying a
+// scheme (e.g. "javascript:", "com.foo.bar:"), so it can never trigger an open
+// redirect or smuggle a dangerous URI scheme into an href.
+func isSafeRelativePath(p string) bool {
+	if len(p) < 2 || p[0] != '/' || p[1] == '/' {
+		return false
+	}
+	// Reject control characters / whitespace that could confuse parsers.
+	for _, r := range p {
+		if r <= ' ' || r == '\\' {
+			return false
+		}
+	}
+	u, err := url.Parse(p)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/")
 }
 
 // --- Passkeys ---

--- a/internal/handler/oauth/device.go
+++ b/internal/handler/oauth/device.go
@@ -277,7 +277,9 @@ func (h *oauthHandler) deviceVerifyPost(w http.ResponseWriter, r *http.Request) 
 	// land on GET /oauth/device/done. Reuses the shared /oauth/passkey-prompt
 	// register endpoints (OAuthFlow: true) via the prompt session cookie.
 	if r.FormValue("webauthn_supported") == "1" && h.shouldPromptPasskey(userID) {
-		h.setPromptSession(w, userID)
+		// This page is rendered directly (not via passkeyPrompt) with a fixed,
+		// server-relative SkipURL, so no next is carried in the prompt cookie.
+		h.setPromptSession(w, userID, "")
 		h.render(w, "passkey_prompt.html", map[string]any{
 			"HideNav":   true,
 			"SkipURL":   "/oauth/device/done",

--- a/internal/handler/oauth/handler.go
+++ b/internal/handler/oauth/handler.go
@@ -204,11 +204,13 @@ func (h *oauthHandler) authorizePost(w http.ResponseWriter, r *http.Request) {
 		redirectURL += "&state=" + url.QueryEscape(state)
 	}
 
-	// If user has no passkeys and the browser supports WebAuthn, show the prompt
+	// If user has no passkeys and the browser supports WebAuthn, show the prompt.
+	// redirectURL is server-built from the registered redirect_uri (validated in
+	// the authorize flow) plus the issued code/state, so we carry it inside the
+	// signed prompt cookie rather than as a client-controllable query parameter.
 	if r.FormValue("webauthn_supported") == "1" && h.shouldPromptPasskey(userID) {
-		h.setPromptSession(w, userID)
-		promptURL := "/oauth/passkey-prompt?next=" + url.QueryEscape(redirectURL)
-		http.Redirect(w, r, promptURL, http.StatusFound)
+		h.setPromptSession(w, userID, redirectURL)
+		http.Redirect(w, r, "/oauth/passkey-prompt", http.StatusFound)
 		return
 	}
 
@@ -604,11 +606,26 @@ func (h *oauthHandler) shouldPromptPasskey(userID string) bool {
 	return len(creds) == 0
 }
 
-// setPromptSession sets a short-lived cookie that identifies the user during the passkey prompt.
-func (h *oauthHandler) setPromptSession(w http.ResponseWriter, userID string) {
-	claims := jwt.RegisteredClaims{
-		Subject:   userID,
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+// promptClaims are the claims carried by the short-lived passkey-prompt cookie.
+// next holds the server-built post-login redirect URL (the registered
+// redirect_uri plus code/state). Because the cookie is HMAC-signed by the
+// server, next is trusted and cannot be tampered with by the client — this is
+// what lets the prompt page render it as a "Not now" deep link (including custom
+// app schemes) without an open-redirect / XSS risk.
+type promptClaims struct {
+	Next string `json:"next,omitempty"`
+	jwt.RegisteredClaims
+}
+
+// setPromptSession sets a short-lived cookie that identifies the user during the
+// passkey prompt and carries the server-validated next redirect URL.
+func (h *oauthHandler) setPromptSession(w http.ResponseWriter, userID, next string) {
+	claims := promptClaims{
+		Next: next,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   userID,
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenStr, err := token.SignedString([]byte(h.sessionKey))
@@ -625,21 +642,28 @@ func (h *oauthHandler) setPromptSession(w http.ResponseWriter, userID string) {
 	})
 }
 
-// promptUserID returns the user ID from the prompt session cookie, or "".
-func (h *oauthHandler) promptUserID(r *http.Request) string {
+// promptSession returns the user ID and trusted next URL from the prompt
+// session cookie. userID is "" when the cookie is missing or invalid.
+func (h *oauthHandler) promptSession(r *http.Request) (userID, next string) {
 	cookie, err := r.Cookie(oauthPromptCookie)
 	if err != nil {
-		return ""
+		return "", ""
 	}
-	claims := &jwt.RegisteredClaims{}
+	claims := &promptClaims{}
 	token, err := jwt.ParseWithClaims(cookie.Value, claims,
 		func(t *jwt.Token) (any, error) { return []byte(h.sessionKey), nil },
 		jwt.WithExpirationRequired(),
 	)
 	if err != nil || !token.Valid {
-		return ""
+		return "", ""
 	}
-	return claims.Subject
+	return claims.Subject, claims.Next
+}
+
+// promptUserID returns the user ID from the prompt session cookie, or "".
+func (h *oauthHandler) promptUserID(r *http.Request) string {
+	userID, _ := h.promptSession(r)
+	return userID
 }
 
 // clearPromptSession removes the prompt cookie.
@@ -666,17 +690,25 @@ func headerOrQuery(r *http.Request, header, query string) string {
 
 // passkeyPrompt renders the passkey registration prompt page during OAuth flow.
 func (h *oauthHandler) passkeyPrompt(w http.ResponseWriter, r *http.Request) {
-	userID := h.promptUserID(r)
+	userID, next := h.promptSession(r)
 	if userID == "" {
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
-	next := r.URL.Query().Get("next")
-	h.render(w, "passkey_prompt.html", map[string]any{
+	data := map[string]any{
 		"HideNav":   true,
-		"SkipURL":   template.URL(next), //nolint:gosec // URL validated against registered redirect_uri before being placed in query string
 		"OAuthFlow": true,
-	})
+	}
+	// next comes from the HMAC-signed prompt cookie, where it was set to the
+	// server-built redirect URL (registered redirect_uri + code/state). It is
+	// therefore trusted and may carry a custom app scheme, so template.URL is
+	// justified. We deliberately ignore any ?next= query parameter, which an
+	// attacker could control and use for an open redirect. If no trusted next
+	// is present, the "Not now" link is simply omitted.
+	if next != "" {
+		data["SkipURL"] = template.URL(next) //nolint:gosec // next is from the HMAC-signed prompt cookie, not client input
+	}
+	h.render(w, "passkey_prompt.html", data)
 }
 
 // passkeyPromptRegisterBegin starts registration using the prompt session.

--- a/internal/handler/oauth/handler_test.go
+++ b/internal/handler/oauth/handler_test.go
@@ -388,12 +388,24 @@ func TestNewRouter_NilService_Returns404(t *testing.T) {
 
 const oauthTestSessionKey = "test-oauth-session-key-long-enough"
 
-// mintPromptCookie creates a signed oauth_passkey_prompt cookie for the given userID.
+// mintPromptCookie creates a signed oauth_passkey_prompt cookie for the given
+// userID, carrying no validated next URL.
 func mintPromptCookie(t *testing.T, userID string) *http.Cookie {
+	return mintPromptCookieWithNext(t, userID, "")
+}
+
+// mintPromptCookieWithNext creates a signed oauth_passkey_prompt cookie carrying
+// a server-validated next URL in the "next" claim. The cookie is HMAC-signed, so
+// its next value is trusted (it was validated against the registered redirect_uri
+// when the cookie was minted in the authorize flow).
+func mintPromptCookieWithNext(t *testing.T, userID, next string) *http.Cookie {
 	t.Helper()
-	claims := jwt.RegisteredClaims{
-		Subject:   userID,
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"exp": jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+	}
+	if next != "" {
+		claims["next"] = next
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := tok.SignedString([]byte(oauthTestSessionKey))
@@ -401,24 +413,66 @@ func mintPromptCookie(t *testing.T, userID string) *http.Cookie {
 	return &http.Cookie{Name: "oauth_passkey_prompt", Value: signed}
 }
 
-// TestPasskeyPrompt_CustomSchemeSkipURL verifies that a custom-scheme next URL
-// (e.g. com.foo.bar://callback) is rendered verbatim in the "Not now" href
-// and not replaced with #ZgotmplZ by html/template's URL sanitizer.
-func TestPasskeyPrompt_CustomSchemeSkipURL(t *testing.T) {
+// TestPasskeyPrompt_TrustedCustomSchemeNext verifies that a custom-scheme next
+// URL carried in the signed prompt cookie (i.e. already validated against the
+// registered redirect_uri) is rendered verbatim in the "Not now" href and not
+// replaced with #ZgotmplZ by html/template's URL sanitizer.
+func TestPasskeyPrompt_TrustedCustomSchemeNext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	svc := mocks.NewMockOAuthServicer(ctrl)
 	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, oauthTestSessionKey, "")
 
 	nextURL := "com.foo.bar://callback?code=abc123"
-	req := httptest.NewRequest(http.MethodGet, "/oauth/passkey-prompt?next="+url.QueryEscape(nextURL), nil)
+	req := httptest.NewRequest(http.MethodGet, "/oauth/passkey-prompt", nil)
+	req.AddCookie(mintPromptCookieWithNext(t, "user-1", nextURL))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, nextURL, "trusted custom-scheme next must render intact")
+	assert.NotContains(t, body, "#ZgotmplZ", "html/template must not sanitize the trusted URL")
+}
+
+// TestPasskeyPrompt_QueryNextIgnored verifies that an attacker-controllable next
+// query parameter is NOT trusted: it is ignored in favour of the signed cookie's
+// validated next value, preventing an open redirect.
+func TestPasskeyPrompt_QueryNextIgnored(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, oauthTestSessionKey, "")
+
+	trusted := "com.foo.bar://callback?code=abc123"
+	evil := "https://evil.example/login"
+	req := httptest.NewRequest(http.MethodGet, "/oauth/passkey-prompt?next="+url.QueryEscape(evil), nil)
+	req.AddCookie(mintPromptCookieWithNext(t, "user-1", trusted))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, trusted, "validated cookie next must render")
+	assert.NotContains(t, body, "evil.example", "attacker query next must not reach the href")
+}
+
+// TestPasskeyPrompt_NoTrustedNext verifies that when the cookie carries no
+// validated next, the prompt renders no "Not now" href (rather than trusting the
+// query parameter or emitting an open redirect).
+func TestPasskeyPrompt_NoTrustedNext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, oauthTestSessionKey, "")
+
+	evil := "https://evil.example/login"
+	req := httptest.NewRequest(http.MethodGet, "/oauth/passkey-prompt?next="+url.QueryEscape(evil), nil)
 	req.AddCookie(mintPromptCookie(t, "user-1"))
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code)
 	body := rr.Body.String()
-	assert.Contains(t, body, nextURL, "SkipURL must render with the custom scheme intact")
-	assert.NotContains(t, body, "#ZgotmplZ", "html/template must not sanitize the trusted URL")
+	assert.NotContains(t, body, "evil.example", "attacker query next must not reach the href")
+	assert.NotContains(t, body, `id="skip-link"`, "no trusted next means no skip link")
 }
 
 // TestPasskeyPromptRegisterFinish_ReadsChallengeFromHeader verifies the finish


### PR DESCRIPTION
Fixes #12

## Problem
Both passkey-prompt handlers wrapped an attacker-controllable `next` query parameter in `template.URL(...)`, disabling `html/template`'s URL-scheme sanitizer, then rendered it as an `<a href>`. The value was never validated → click-through open redirect and a latent reflected `javascript:` XSS (blocked today only by the CSP). The OAuth handler's `//nolint:gosec` comment claimed the URL was "validated against registered redirect_uri" — it was not; the handler only read the userID from the prompt cookie.

## Fix
- **Admin path** (`internal/handler/admin/handler.go`): added `isSafeRelativePath` (requires a single leading `/`, rejects protocol-relative `//host`, absolute URLs, any scheme, and control/whitespace/backslash). Invalid `next` falls back to `/admin/`, and `SkipURL` is rendered as a plain string (dropped `template.URL`) so the template's URL filter applies as defense in depth.
- **OAuth path** (`internal/handler/oauth/handler.go`): the prompt cookie couldn't see the registered `redirect_uri`, and custom-scheme deep links must keep working. The server-built, already-validated redirect URL (registered `redirect_uri` + code/state) is now carried **inside the HMAC-signed prompt cookie** via a new `next` claim. `passkeyPrompt` reads `next` only from the signed cookie and ignores `?next=`. Because the value is cryptographically server-trusted, `template.URL` is justified and deep links are preserved. The device-flow caller passes `next=""` (it renders a fixed SkipURL).

## Tests
Replaced the two tests that locked in the unsafe behavior:
- Admin: `TestPasskeyPrompt_SafeRelativeNext` (legit relative path renders) + `TestPasskeyPrompt_UnsafeNextFallsBack` (table of `https://`, `//host`, `javascript:`, custom scheme, leading whitespace → all fall back to `/admin/`).
- OAuth: `TestPasskeyPrompt_TrustedCustomSchemeNext` (signed-cookie custom scheme renders intact), `TestPasskeyPrompt_QueryNextIgnored` (attacker `?next=` ignored), `TestPasskeyPrompt_NoTrustedNext` (no skip link).

Confirmed failing on old code, passing after. `go build ./...`, `go vet`, and `go test ./...` all pass. Post-registration "continue" behavior is preserved.

The CSP is intentionally kept as the second layer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XP9JVCj1EQErwKZj9nedHM)_