### PR TITLE
Audit WebAuthn authenticator clone-warning on passkey assertion

### DIFF
--- a/internal/domain/webauthn.go
+++ b/internal/domain/webauthn.go
@@ -67,4 +67,8 @@ const (
 	EventPasskeyLoginSuccess    = "passkey_login_success"
 	EventPasskeyLoginFailure    = "passkey_login_failure"
 	EventPasskeyDeleted         = "passkey_deleted"
+	// EventPasskeyCloneWarning is emitted when an assertion presents a signature
+	// counter that regressed against the stored non-zero counter — a signal that
+	// the authenticator may have been cloned (WebAuthn §7.2 step 17).
+	EventPasskeyCloneWarning = "passkey_clone_warning"
 )

--- a/internal/service/webauthn_service.go
+++ b/internal/service/webauthn_service.go
@@ -370,6 +370,21 @@ func (s *WebAuthnService) FinishLogin(challengeID string, r *http.Request, devic
 	if err != nil {
 		return nil, fmt.Errorf("get stored credential: %w", err)
 	}
+
+	// Authenticator clone detection. go-webauthn sets CloneWarning when the
+	// presented signature counter regressed against the stored one (and they
+	// are not both zero). A counter regression on a counter-bearing authenticator
+	// means the credential's private key may exist on more than one device.
+	// We surface it as an audit signal rather than hard-failing: many synced
+	// passkeys legitimately report SignCount==0 on every assertion, and the
+	// library already exempts that all-zero case from CloneWarning.
+	if ShouldWarnPasskeyClone(credential.Authenticator.CloneWarning, storedCred.SignCount, credential.Authenticator.SignCount) {
+		username := s.lookupUsername(authenticatedUserID)
+		detail := fmt.Sprintf("credential_id=%s stored_sign_count=%d presented_sign_count=%d",
+			storedCred.ID, storedCred.SignCount, credential.Authenticator.SignCount)
+		s.recordEvent(domain.EventPasskeyCloneWarning, authenticatedUserID, username, detail)
+	}
+
 	now := time.Now().UTC()
 	s.credentials.UpdateSignCount(storedCred.ID, credential.Authenticator.SignCount) //nolint:errcheck
 	s.credentials.UpdateLastUsed(storedCred.ID, now)                                 //nolint:errcheck
@@ -450,6 +465,18 @@ func (s *WebAuthnService) lookupUsername(userID string) string {
 		return u.Username
 	}
 	return userID
+}
+
+// ShouldWarnPasskeyClone reports whether an assertion should be treated as a
+// potential authenticator-clone signal.
+//
+// cloneWarning is the flag set by go-webauthn (true when the presented counter
+// regressed against the stored one and they were not both zero). We additionally
+// require a non-zero stored counter so that synced/backup-eligible passkeys —
+// which legitimately report SignCount==0 on every assertion — are never flagged,
+// even if a future library change were to set CloneWarning for the zero case.
+func ShouldWarnPasskeyClone(cloneWarning bool, storedSignCount, presentedSignCount uint32) bool {
+	return cloneWarning && storedSignCount > 0
 }
 
 // recordEvent writes an audit event, ignoring errors (best-effort).

--- a/internal/service/webauthn_service_test.go
+++ b/internal/service/webauthn_service_test.go
@@ -304,6 +304,40 @@ func TestWebAuthnService_FinishLogin_InvalidSessionData(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// --- Clone detection ---
+
+func TestWebAuthnService_CloneWarning_RegressionOnCounterBearingAuthenticator(t *testing.T) {
+	// A non-zero stored counter with a presented count <= stored is a genuine
+	// clone signal: the library sets CloneWarning=true and leaves SignCount
+	// unchanged. The service must surface this as a clone-warning audit event.
+	assert.True(t, service.ShouldWarnPasskeyClone(true, 42, 7),
+		"regression on a non-zero counter must warn")
+	assert.True(t, service.ShouldWarnPasskeyClone(true, 42, 42),
+		"equal counter on a non-zero counter must warn")
+}
+
+func TestWebAuthnService_CloneWarning_SyncedZeroCountPasskeyDoesNotWarn(t *testing.T) {
+	// Synced/backup-eligible passkeys legitimately report SignCount==0 on every
+	// assertion. The library never sets CloneWarning for the all-zero case, and
+	// even defensively the service must not warn when the stored counter is 0.
+	assert.False(t, service.ShouldWarnPasskeyClone(false, 0, 0),
+		"all-zero synced passkey must not warn")
+	assert.False(t, service.ShouldWarnPasskeyClone(false, 0, 5),
+		"zero stored counter must not warn")
+	assert.False(t, service.ShouldWarnPasskeyClone(true, 0, 0),
+		"a zero stored counter must never be treated as a clone regression")
+}
+
+func TestWebAuthnService_CloneWarning_NoWarningWhenLibraryClear(t *testing.T) {
+	// Normal monotonic progress: library reports no clone warning.
+	assert.False(t, service.ShouldWarnPasskeyClone(false, 7, 42),
+		"monotonic counter increase must not warn")
+}
+
+func TestWebAuthnEvent_CloneWarningConstantDefined(t *testing.T) {
+	assert.Equal(t, "passkey_clone_warning", domain.EventPasskeyCloneWarning)
+}
+
 // --- ListCredentials ---
 
 func TestWebAuthnService_ListCredentials(t *testing.T) {

--- a/internal/ui/templates/audit_log.html
+++ b/internal/ui/templates/audit_log.html
@@ -50,6 +50,7 @@
                 {{else if eq .EventType "passkey_login_success"}}<span class="evt-success">passkey login</span>
                 {{else if eq .EventType "passkey_login_failure"}}<span class="evt-danger">passkey login failed</span>
                 {{else if eq .EventType "passkey_deleted"}}passkey deleted
+                {{else if eq .EventType "passkey_clone_warning"}}<span class="evt-danger">passkey clone warning</span>
                 {{else if eq .EventType "backup_success"}}<span class="evt-success">backup</span>
                 {{else if eq .EventType "backup_failure"}}<span class="evt-danger">backup failed</span>
                 {{else}}{{.EventType}}{{end}}


### PR DESCRIPTION
Fixes #13

## Problem
During passkey assertion, `go-webauthn` performs sign-count regression checking and sets `credential.Authenticator.CloneWarning` when a cloned authenticator is suspected. `WebAuthnService.FinishLogin` never inspected this flag — it wrote the (unchanged) sign count back, issued tokens, and emitted no signal. The one signal WebAuthn provides for detecting credential cloning was silently dropped.

Confirmed against go-webauthn v0.16.1 `UpdateCounter`: a regression on a counter-bearing authenticator sets `CloneWarning = true` and leaves `SignCount` unchanged, while the all-zero synced-passkey case is exempt.

## Fix (minimum bar: audit event)
- Added `EventPasskeyCloneWarning = "passkey_clone_warning"` in `internal/domain/webauthn.go`.
- `FinishLogin` now inspects `CloneWarning` via a new pure helper `ShouldWarnPasskeyClone(cloneWarning, storedSignCount, presentedSignCount)` and records an audit event (credential ID + stored vs presented counts) via the existing `recordEvent`/`lookupUsername` mechanism.
- The helper requires `cloneWarning && storedSignCount > 0`, so synced zero-count passkeys can never be flagged.
- Rendered the new event type as a danger badge in `internal/ui/templates/audit_log.html`.

Login still succeeds and no revocation is performed — the issue explicitly prefers the lower-risk audit-only approach; forced revocation would need new plumbing and risks locking out users on benign counter glitches.

## Tests
Four tests around `ShouldWarnPasskeyClone`: regression on a non-zero stored counter warns; all-zero / zero-stored-counter synced passkey does not; monotonic progress does not. Confirmed failing (undefined symbols) before, passing after. `go build ./...`, `go vet`, and full `go test ./...` (incl. spec coverage) pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XP9JVCj1EQErwKZj9nedHM)_