### PR TITLE
Authenticate confidential clients and enforce authorization_code grant on code exchange

### DIFF
--- a/internal/domain/oauth.go
+++ b/internal/domain/oauth.go
@@ -2,6 +2,13 @@ package domain
 
 import "time"
 
+// Grant type identifiers for the OAuth 2.0 flows this server supports.
+// (GrantTypeDeviceCode lives in device_flow.go.)
+const (
+	GrantTypeAuthorizationCode = "authorization_code"
+	GrantTypeClientCredentials = "client_credentials"
+)
+
 // OAuthClient is a registered OAuth application persisted to DB.
 //
 //go:generate mockgen -destination=../mocks/mock_oauth_client_repository.go -package=mocks github.com/sweeney/identity/internal/domain OAuthClientRepository

--- a/internal/handler/oauth/client_auth_test.go
+++ b/internal/handler/oauth/client_auth_test.go
@@ -485,3 +485,140 @@ func TestIntrospect_ServiceToken_IncludesAudClaim(t *testing.T) {
 	assert.Equal(t, true, body["active"])
 	assert.Equal(t, "https://api.example.com", body["aud"], "introspect response must include aud claim matching the token's audience")
 }
+
+// --- authorization_code: confidential-client authentication (RFC 6749 §4.1.3) ---
+
+func authCodeForm(extra url.Values) url.Values {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"conf-client"},
+		"code":          {"code-abc"},
+		"redirect_uri":  {"https://app.example.com/callback"},
+		"code_verifier": {"verifier-xyz"},
+	}
+	for k, v := range extra {
+		form[k] = v
+	}
+	return form
+}
+
+func confidentialAuthCodeClient() *domain.OAuthClient {
+	return &domain.OAuthClient{
+		ID:                      "conf-client",
+		SecretHash:              mustHash("s3cret"),
+		GrantTypes:              []string{"authorization_code"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+	}
+}
+
+// A confidential auth-code client (one with a registered secret) must present a
+// valid client secret to exchange a code. Missing secret → invalid_client.
+func TestTokenAuthCode_Confidential_MissingSecret(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+
+	svc.EXPECT().GetClient("conf-client").Return(confidentialAuthCodeClient(), nil)
+	// ExchangeCode must NOT be reached when client auth fails.
+
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, "", "")
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(authCodeForm(nil).Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Equal(t, "invalid_client", body["error"])
+}
+
+// Wrong secret → invalid_client.
+func TestTokenAuthCode_Confidential_WrongSecret(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+
+	svc.EXPECT().GetClient("conf-client").Return(confidentialAuthCodeClient(), nil)
+
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, "", "")
+	form := authCodeForm(url.Values{"client_secret": {"wrong"}})
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Equal(t, "invalid_client", body["error"])
+}
+
+// Correct secret (via Basic auth) → the exchange proceeds.
+func TestTokenAuthCode_Confidential_ValidSecret(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+
+	svc.EXPECT().GetClient("conf-client").Return(confidentialAuthCodeClient(), nil)
+	svc.EXPECT().ExchangeCode("conf-client", "code-abc", "https://app.example.com/callback", "verifier-xyz").
+		Return(&service.LoginResult{AccessToken: "at", TokenType: "Bearer", ExpiresIn: 900, RefreshToken: "rt"}, nil)
+
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, "", "")
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(authCodeForm(nil).Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("conf-client:s3cret")))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Equal(t, "at", body["access_token"])
+}
+
+// A public auth-code client (no secret) still succeeds with PKCE alone.
+func TestTokenAuthCode_Public_NoSecretRequired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+
+	svc.EXPECT().GetClient("conf-client").Return(&domain.OAuthClient{
+		ID:         "conf-client",
+		GrantTypes: []string{"authorization_code"},
+		// no SecretHash → public client
+	}, nil)
+	svc.EXPECT().ExchangeCode("conf-client", "code-abc", "https://app.example.com/callback", "verifier-xyz").
+		Return(&service.LoginResult{AccessToken: "at", TokenType: "Bearer", ExpiresIn: 900, RefreshToken: "rt"}, nil)
+
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, "", "")
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(authCodeForm(nil).Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+// A client lacking the authorization_code grant is rejected at the token
+// exchange with unauthorized_client (grant-type confusion).
+func TestTokenAuthCode_WrongGrantType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+
+	// Public client (no secret) so client-auth is skipped; ExchangeCode enforces
+	// the grant-type gate and returns ErrUnauthorizedClient.
+	svc.EXPECT().GetClient("conf-client").Return(&domain.OAuthClient{
+		ID:         "conf-client",
+		GrantTypes: []string{"client_credentials"},
+	}, nil)
+	svc.EXPECT().ExchangeCode("conf-client", "code-abc", "https://app.example.com/callback", "verifier-xyz").
+		Return(nil, service.ErrUnauthorizedClient)
+
+	h := oauth.NewRouter(svc, "", nil, nil, nil, nil, "", "")
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(authCodeForm(nil).Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&body))
+	assert.Equal(t, "unauthorized_client", body["error"])
+}

--- a/internal/handler/oauth/handler.go
+++ b/internal/handler/oauth/handler.go
@@ -99,6 +99,8 @@ func (h *oauthHandler) authorizeGet(w http.ResponseWriter, r *http.Request) {
 			h.renderError(w, "Unknown Client", "The client_id is not registered.")
 		case errors.Is(err, service.ErrInvalidRedirectURI):
 			h.renderError(w, "Invalid Redirect URI", "The redirect_uri is not registered for this client.")
+		case errors.Is(err, service.ErrUnauthorizedClient):
+			h.renderError(w, "Unauthorized Client", "This client is not authorized for the authorization_code flow.")
 		default:
 			h.renderError(w, "Error", "An unexpected error occurred.")
 		}
@@ -324,9 +326,26 @@ func (h *oauthHandler) tokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Confidential-client authentication (RFC 6749 §4.1.3 / §3.2.1): if the client
+	// has a registered secret, it MUST authenticate at the token endpoint. Public
+	// clients (no secret) continue with PKCE alone. The grant-type gate itself lives
+	// in ExchangeCode.
+	if client, err := h.svc.GetClient(clientID); err == nil && client.SecretHash != "" {
+		creds, ok := extractClientCredentials(r)
+		if !ok || creds.ClientID != clientID || !verifyClientSecret(client, creds.ClientSecret) {
+			w.Header().Set("WWW-Authenticate", "Basic")
+			oauthErrorWithStatus(w, http.StatusUnauthorized, "invalid_client", "Client authentication failed.")
+			return
+		}
+	}
+
 	result, err := h.svc.ExchangeCode(clientID, code, redirectURI, codeVerifier)
 	if err != nil {
 		switch {
+		case errors.Is(err, service.ErrUnknownClient):
+			oauthError(w, "invalid_client", "Unknown client.")
+		case errors.Is(err, service.ErrUnauthorizedClient):
+			oauthError(w, "unauthorized_client", "This client is not authorized for the authorization_code grant.")
 		case errors.Is(err, service.ErrInvalidAuthCode),
 			errors.Is(err, service.ErrAuthCodeAlreadyUsed),
 			errors.Is(err, service.ErrAuthCodeExpired):

--- a/internal/handler/oauth/handler_test.go
+++ b/internal/handler/oauth/handler_test.go
@@ -89,6 +89,21 @@ func TestAuthorizeGet_UnknownClient(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "Unknown Client")
 }
 
+// A client not registered for the authorization_code grant must be rejected at
+// /oauth/authorize (grant-type confusion).
+func TestAuthorizeGet_UnauthorizedClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mocks.NewMockOAuthServicer(ctrl)
+
+	svc.EXPECT().ValidateAuthorizeRequest("client-1", gomock.Any()).Return(nil, service.ErrUnauthorizedClient)
+
+	h := newTestRouter(svc)
+	rr := getAuthorize(t, h, validAuthorizeParams())
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Unauthorized Client")
+}
+
 func TestAuthorizeGet_NonS256Method(t *testing.T) {
 	h := newTestRouter(mocks.NewMockOAuthServicer(gomock.NewController(t)))
 	params := validAuthorizeParams()
@@ -267,6 +282,7 @@ func TestTokenEndpoint_AuthCode_Success(t *testing.T) {
 		ExpiresIn:    900,
 		RefreshToken: "refresh-token",
 	}
+	svc.EXPECT().GetClient("client-1").Return(&domain.OAuthClient{ID: "client-1"}, nil)
 	svc.EXPECT().ExchangeCode("client-1", "code-abc", "https://myapp.example.com/callback", "verifier-xyz").
 		Return(result, nil)
 
@@ -290,6 +306,7 @@ func TestTokenEndpoint_AuthCode_InvalidGrant(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	svc := mocks.NewMockOAuthServicer(ctrl)
 
+	svc.EXPECT().GetClient("client-1").Return(&domain.OAuthClient{ID: "client-1"}, nil)
 	svc.EXPECT().ExchangeCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, service.ErrInvalidAuthCode)
 
@@ -322,6 +339,7 @@ func TestTokenEndpoint_AuthCode_UnifiedErrorMessage(t *testing.T) {
 		t.Run(svcErr.Error(), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			svc := mocks.NewMockOAuthServicer(ctrl)
+			svc.EXPECT().GetClient("client-1").Return(&domain.OAuthClient{ID: "client-1"}, nil)
 			svc.EXPECT().ExchangeCode(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, svcErr)
 

--- a/internal/integration/e2e_oauth_test.go
+++ b/internal/integration/e2e_oauth_test.go
@@ -112,6 +112,7 @@ func registerOAuthClient(t *testing.T, database *db.Database, id, name string, r
 		ID:           id,
 		Name:         name,
 		RedirectURIs: redirectURIs,
+		GrantTypes:   []string{"authorization_code"},
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	})

--- a/internal/service/oauth_service.go
+++ b/internal/service/oauth_service.go
@@ -82,6 +82,12 @@ func (s *OAuthService) ValidateAuthorizeRequest(clientID, redirectURI string) (*
 		return nil, ErrInvalidRedirectURI
 	}
 
+	// A client must be registered for the authorization_code grant to drive the
+	// interactive /oauth/authorize flow (RFC 6749 §3.2.1, grant-type confusion).
+	if !client.HasGrantType(domain.GrantTypeAuthorizationCode) {
+		return nil, ErrUnauthorizedClient
+	}
+
 	return client, nil
 }
 
@@ -166,7 +172,23 @@ func (s *OAuthService) AuthorizeByUserID(clientID, redirectURI, userID, username
 }
 
 // ExchangeCode validates the authorization code and PKCE, then issues tokens.
+//
+// The client is resolved up front so the authorization_code grant type can be
+// enforced (RFC 6749 §3.2.1): a client registered for only client_credentials
+// or the device flow must not be able to exchange a code for a user token
+// (grant-type confusion).
 func (s *OAuthService) ExchangeCode(clientID, rawCode, redirectURI, codeVerifier string) (*LoginResult, error) {
+	client, err := s.clients.GetByID(clientID)
+	if errors.Is(err, domain.ErrNotFound) {
+		return nil, ErrUnknownClient
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get client: %w", err)
+	}
+	if !client.HasGrantType(domain.GrantTypeAuthorizationCode) {
+		return nil, ErrUnauthorizedClient
+	}
+
 	codeHash := HashToken(rawCode)
 	code, err := s.codes.GetByHash(codeHash)
 	if errors.Is(err, domain.ErrNotFound) {
@@ -200,12 +222,7 @@ func (s *OAuthService) ExchangeCode(clientID, rawCode, redirectURI, codeVerifier
 		return nil, fmt.Errorf("mark code used: %w", err)
 	}
 
-	var audience string
-	if client, err := s.clients.GetByID(clientID); err == nil {
-		audience = client.Audience
-	}
-
-	return s.auth.IssueTokensForUser(code.UserID, audience)
+	return s.auth.IssueTokensForUser(code.UserID, client.Audience)
 }
 
 // RefreshToken delegates to the underlying auth service refresh.
@@ -218,7 +235,7 @@ const serviceTokenTTL = 15 * time.Minute
 // IssueClientCredentials issues an access token for the client_credentials grant.
 // requestedScope may be empty (defaults to all client scopes).
 func (s *OAuthService) IssueClientCredentials(client *domain.OAuthClient, requestedScope, ip string) (*ClientCredentialsResult, error) {
-	if !client.HasGrantType("client_credentials") {
+	if !client.HasGrantType(domain.GrantTypeClientCredentials) {
 		return nil, ErrUnauthorizedClient
 	}
 

--- a/internal/service/oauth_service_test.go
+++ b/internal/service/oauth_service_test.go
@@ -83,6 +83,20 @@ func TestOAuthService_ValidateAuthorizeRequest_InvalidRedirectURI(t *testing.T) 
 	assert.ErrorIs(t, err, service.ErrInvalidRedirectURI)
 }
 
+// A client not registered for the authorization_code grant must not be allowed
+// to drive the interactive /oauth/authorize flow (grant-type confusion).
+func TestOAuthService_ValidateAuthorizeRequest_WrongGrantType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc, _, clients, _ := newOAuthService(t, ctrl)
+
+	client := testClient()
+	client.GrantTypes = []string{"client_credentials"} // no authorization_code
+	clients.EXPECT().GetByID("client-1").Return(client, nil)
+
+	_, err := svc.ValidateAuthorizeRequest("client-1", "https://myapp.example.com/callback")
+	assert.ErrorIs(t, err, service.ErrUnauthorizedClient)
+}
+
 // --- Authorize ---
 
 func TestOAuthService_Authorize_Success(t *testing.T) {
@@ -190,17 +204,42 @@ func TestOAuthService_ExchangeCode_NoAudience(t *testing.T) {
 
 func TestOAuthService_ExchangeCode_InvalidCode(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	svc, _, _, codes := newOAuthService(t, ctrl)
+	svc, _, clients, codes := newOAuthService(t, ctrl)
 
+	clients.EXPECT().GetByID("client-1").Return(testClient(), nil)
 	codes.EXPECT().GetByHash(gomock.Any()).Return(nil, domain.ErrNotFound)
 
 	_, err := svc.ExchangeCode("client-1", "bad-code", "https://myapp.example.com/callback", "verifier")
 	assert.ErrorIs(t, err, service.ErrInvalidAuthCode)
 }
 
+// A client not registered for the authorization_code grant must not be able to
+// exchange a code, even if it somehow obtained one (grant-type confusion).
+func TestOAuthService_ExchangeCode_WrongGrantType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc, _, clients, _ := newOAuthService(t, ctrl)
+
+	client := testClient()
+	client.GrantTypes = []string{"client_credentials"} // no authorization_code
+	clients.EXPECT().GetByID("client-1").Return(client, nil)
+
+	_, err := svc.ExchangeCode("client-1", "some-code", "https://myapp.example.com/callback", "verifier")
+	assert.ErrorIs(t, err, service.ErrUnauthorizedClient)
+}
+
+func TestOAuthService_ExchangeCode_UnknownClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc, _, clients, _ := newOAuthService(t, ctrl)
+
+	clients.EXPECT().GetByID("client-1").Return(nil, domain.ErrNotFound)
+
+	_, err := svc.ExchangeCode("client-1", "some-code", "https://myapp.example.com/callback", "verifier")
+	assert.ErrorIs(t, err, service.ErrUnknownClient)
+}
+
 func TestOAuthService_ExchangeCode_ClientMismatch(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	svc, _, _, codes := newOAuthService(t, ctrl)
+	svc, _, clients, codes := newOAuthService(t, ctrl)
 
 	rawCode := "some-code"
 	codeHash := service.HashToken(rawCode)
@@ -216,6 +255,7 @@ func TestOAuthService_ExchangeCode_ClientMismatch(t *testing.T) {
 		ExpiresAt:     now.Add(60 * time.Second),
 	}
 
+	clients.EXPECT().GetByID("client-1").Return(testClient(), nil)
 	codes.EXPECT().GetByHash(codeHash).Return(authCode, nil)
 
 	_, err := svc.ExchangeCode("client-1", rawCode, "https://myapp.example.com/callback", "verifier")
@@ -224,7 +264,7 @@ func TestOAuthService_ExchangeCode_ClientMismatch(t *testing.T) {
 
 func TestOAuthService_ExchangeCode_AlreadyUsed(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	svc, _, _, codes := newOAuthService(t, ctrl)
+	svc, _, clients, codes := newOAuthService(t, ctrl)
 
 	rawCode := "used-code"
 	codeHash := service.HashToken(rawCode)
@@ -242,6 +282,7 @@ func TestOAuthService_ExchangeCode_AlreadyUsed(t *testing.T) {
 		UsedAt:        &usedAt,
 	}
 
+	clients.EXPECT().GetByID("client-1").Return(testClient(), nil)
 	codes.EXPECT().GetByHash(codeHash).Return(authCode, nil)
 
 	_, err := svc.ExchangeCode("client-1", rawCode, "https://myapp.example.com/callback", "verifier")
@@ -250,7 +291,7 @@ func TestOAuthService_ExchangeCode_AlreadyUsed(t *testing.T) {
 
 func TestOAuthService_ExchangeCode_Expired(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	svc, _, _, codes := newOAuthService(t, ctrl)
+	svc, _, clients, codes := newOAuthService(t, ctrl)
 
 	rawCode := "expired-code"
 	codeHash := service.HashToken(rawCode)
@@ -266,6 +307,7 @@ func TestOAuthService_ExchangeCode_Expired(t *testing.T) {
 		ExpiresAt:     now.Add(-1 * time.Minute),
 	}
 
+	clients.EXPECT().GetByID("client-1").Return(testClient(), nil)
 	codes.EXPECT().GetByHash(codeHash).Return(authCode, nil)
 
 	_, err := svc.ExchangeCode("client-1", rawCode, "https://myapp.example.com/callback", "verifier")
@@ -274,7 +316,7 @@ func TestOAuthService_ExchangeCode_Expired(t *testing.T) {
 
 func TestOAuthService_ExchangeCode_PKCEFailed(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	svc, _, _, codes := newOAuthService(t, ctrl)
+	svc, _, clients, codes := newOAuthService(t, ctrl)
 
 	verifier := "correct-verifier"
 	challenge := pkceChallenge(verifier)
@@ -293,6 +335,7 @@ func TestOAuthService_ExchangeCode_PKCEFailed(t *testing.T) {
 		ExpiresAt:     now.Add(60 * time.Second),
 	}
 
+	clients.EXPECT().GetByID("client-1").Return(testClient(), nil)
 	codes.EXPECT().GetByHash(codeHash).Return(authCode, nil)
 
 	_, err := svc.ExchangeCode("client-1", rawCode, "https://myapp.example.com/callback", "wrong-verifier")


### PR DESCRIPTION
Fixes #14

## Problem
The authorization-code token exchange relied entirely on PKCE:
1. **No client-secret authentication.** `tokenAuthCode` read only `client_id`/`code`/`redirect_uri`/`code_verifier`; `ExchangeCode` verified PKCE and code binding but never authenticated the client, even confidential ones with a `SecretHash`.
2. **No grant-type check.** Neither the authorize handlers nor `ExchangeCode` checked `HasGrantType("authorization_code")`, so a `client_credentials`- or `device_code`-only client could drive `/oauth/authorize` and mint a full user token pair (grant-type confusion).

There was no named constant for the grant, so this PR adds `domain.GrantTypeAuthorizationCode` and `domain.GrantTypeClientCredentials`.

## Fix
- **Grant-type gate** (`internal/service/oauth_service.go`): `ValidateAuthorizeRequest` (covering `authorizeGet`/`authorizePost`/`authorizePasskey`) and `ExchangeCode` now reject clients lacking the `authorization_code` grant with `ErrUnauthorizedClient` → `unauthorized_client`. `ExchangeCode` resolves the client up front (unknown → `invalid_client`); the pre-existing audience lookup was folded into this single fetch.
- **Confidential-client auth** (`internal/handler/oauth/handler.go`): `tokenAuthCode` fetches the client and, if it has a `SecretHash`, requires and verifies a secret (Basic or form body) via the existing `extractClientCredentials`/`verifyClientSecret`, matching `client_id`. Missing/wrong secret → `401 invalid_client`. Public clients keep the PKCE-only flow. `authorizeGet` renders a dedicated "Unauthorized Client" page for the new error.

## Tests
Service tests for the grant-type gate at both `ValidateAuthorizeRequest` and `ExchangeCode` plus unknown-client; handler tests: confidential client missing/wrong secret → `invalid_client`, valid Basic secret → success, public client succeeds with PKCE alone, wrong-grant client → `unauthorized_client`, and grant-type rejection at `GET /oauth/authorize`. Confirmed failing before, passing after.

## Fixture updated
`internal/integration/e2e_oauth_test.go` `registerOAuthClient` registered clients with no grant types; added `GrantTypes: []string{"authorization_code"}` so the legitimate flow passes. The admin create handler already defaults absent `grant_types` to `authorization_code`, so the admin UI and e2e shell scripts need no change.

`go build ./...`, `go vet`, `go test ./...`, and `go test -tags integration ./...` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XP9JVCj1EQErwKZj9nedHM)_